### PR TITLE
chore(cli): add new workflow parameters

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,18 @@ on:
         required: false
         type: string
 
+      parallel:
+        description: 'Upload directory blocks in parallel'
+        required: false
+        type: boolean
+        default: true
+
+      upload-concurrency:
+        description: 'Number of parallel block uploads'
+        required: false
+        type: number
+        default: 15
+
       skip-cache:
         description: 'Skip deployment cache and force re-upload'
         required: false
@@ -246,6 +258,7 @@ jobs:
         run: |
           ARGS=(./build --json)
           [[ -n "$BULLETIN_RPC" ]] && ARGS+=(--bulletin-rpc "$BULLETIN_RPC")
+          [[ "$PARALLEL" == "true" ]] && ARGS+=(--parallel --concurrency "$UPLOAD_CONCURRENCY")
 
           for ATTEMPT in $(seq 1 "$MAX_RETRIES"); do
             echo "Upload attempt $ATTEMPT/$MAX_RETRIES"
@@ -263,6 +276,7 @@ jobs:
             fi
 
             echo "::warning::Upload attempt $ATTEMPT failed"
+            echo "$RESULT"
             [[ "$ATTEMPT" -lt "$MAX_RETRIES" ]] && sleep "$RETRY_DELAY"
           done
 
@@ -270,6 +284,8 @@ jobs:
           exit 1
         env:
           BULLETIN_RPC: ${{ inputs.bulletin-rpc }}
+          PARALLEL: ${{ inputs.parallel }}
+          UPLOAD_CONCURRENCY: ${{ inputs.upload-concurrency }}
           MAX_RETRIES: ${{ inputs.max-retries }}
           RETRY_DELAY: ${{ inputs.retry-delay }}
 


### PR DESCRIPTION
## Description
Add parallel upload support to the reusable deploy workflow. Uploads now run with `--parallel --concurrency 15` by default, significantly reducing Bulletin upload time for multi-block directories. Also surfaces upload error output on failure for easier debugging.

## Type
- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Chore

## Package
- [ ] `@dotns/cli`
- [x] Root/monorepo
- [ ] Documentation

## Related Issues

## Fixes

## Checklist
### Code
- [x] Follows project style
- [x] `bun run lint` passes
- [x] `bun run format` passes
- [x] `bun run typecheck` passes

### Documentation
- [x] README updated if needed
- [x] Types updated if needed

### Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes documented below

## Testing
How to test:
1. Open a PR on a repo that calls `deploy.yml`;  the Upload to Bulletin step should show `--parallel --concurrency 15` in the command args
2. Force a upload failure (e.g. invalid RPC) and confirm the error output is now visible in the logs instead of silently retrying

## Notes
Two new optional inputs added to `deploy.yml`: `parallel` (default: `true`) and `upload-concurrency` (default: `15`). Existing callers pick up the defaults automatically with no changes needed. Error output from failed upload attempts is now printed to the log via `echo "$RESULT"` on the failure path.