### PR TITLE
feat(cli): fix issue with content hash handling

### DIFF
--- a/packages/cli/src/commands/contentHash.ts
+++ b/packages/cli/src/commands/contentHash.ts
@@ -1,40 +1,24 @@
 import chalk from "chalk";
 import type { Ora } from "ora";
 import { namehash, type Address, type Hex, zeroAddress, checksumAddress } from "viem";
-import { decode, encode, getCodec, cidForWeb } from "@ensdomains/content-hash";
 import type { PolkadotSigner } from "polkadot-api";
 import type { ReviveClientWrapper } from "../client/polkadotClient";
 import { CONTRACTS, DOTNS_REGISTRY_ABI, DOTNS_CONTENT_RESOLVER_ABI } from "../utils/constants";
 import { performContractCall, submitContractTransaction } from "../utils/contractInteractions";
+import { decodeIpfsContenthash, encodeIpfsContenthash } from "../bulletin/cid";
 
 function decodeContenthashToCid(contenthash: Hex): string {
   if (contenthash === "0x" || contenthash === "0x0" || contenthash.length < 6) {
     return "No CID set";
   }
 
-  try {
-    const codec = getCodec(contenthash);
-
-    if (codec !== "ipfs") {
-      return `Unsupported codec: ${codec}`;
-    }
-
-    const decoded = decode(contenthash);
-    return cidForWeb(decoded);
-  } catch (error) {
-    console.error("Error decoding contenthash:", error);
-    return `Unable to decode: ${contenthash}`;
-  }
+  const cid = decodeIpfsContenthash(contenthash);
+  return cid ?? `Unable to decode: ${contenthash}`;
 }
 
 function encodeCidToContenthash(cidString: string): Hex {
-  try {
-    const encoded = encode("ipfs", cidString);
-    return `0x${encoded}` as Hex;
-  } catch (error) {
-    console.error("Error encoding CID to contenthash:", error);
-    throw new Error(`Invalid CID: ${cidString}`);
-  }
+  const encoded = encodeIpfsContenthash(cidString);
+  return `0x${encoded}` as Hex;
 }
 
 export async function viewDomainContentHash(


### PR DESCRIPTION
## Description
Fix contenthash decoding in `contentManagement.ts`. The `decodeContenthashToCid` function passed `0x`-prefixed hex directly to `@ensdomains/content-hash` which expects raw hex without the prefix. This caused `getCodec` to misparse the bytes, producing **Invalid CID version 112** errors when reading existing on-chain contenthashes. The fix consolidates on the shared `cid.ts` utilities which already handle `0x` stripping correctly.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Chore

## Package
- [x] `@dotns/cli`
- [ ] Root/monorepo
- [ ] Documentation

## Related Issues

## Fixes

## Checklist
### Code
- [x] Follows project style
- [x] `bun run lint` passes
- [x] `bun run format` passes
- [x] `bun run typecheck` passes

### Documentation
- [x] README updated if needed
- [x] Types updated if needed

### Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes documented below

## Testing
How to test:
1. Set a contenthash on a domain: `dotns content set <name> <cid>`,  **the current** field should now decode correctly on first run instead of showing **Unable to decode**
2. View an existing contenthash: `dotns content view <name>`, should display the CID instead of erroring with **Invalid CID version 112**

## Notes
Same root cause as the gateway `slice(2)` bug. The `@ensdomains/content-hash` library expects raw hex (`e301017012...`) but was receiving `0x`-prefixed hex (`0xe301017012...`), causing byte offsets to shift. The `cid.ts` utility already handled this correctly,  `contentManagement.ts` had a duplicate implementation that didn't.