### PR TITLE
chore: Undo subname deployment hack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,16 +36,6 @@ on:
         type: string
         default: 'pr-number'
 
-      # HACK: Workaround for DotNS Store contract key collision. The store key
-      # is keccak256("dotns.registered", labelhash) — scoped by label only, not
-      # by parent. This means the same owner cannot register the same subname
-      # label under multiple parents. Adding a suffix makes each label unique.
-      # TODO: Remove once the contract uses namehash instead of labelhash for the key.
-      subname-suffix:
-        description: 'Optional suffix appended to the subname (e.g. 0 → pr42-0). Use to avoid store key collisions when deploying the same PR to multiple base domains.'
-        required: false
-        type: string
-
       register-base:
         description: 'Attempt base domain registration if not already owned'
         required: false
@@ -182,8 +172,6 @@ jobs:
                 ;;
             esac
 
-            [[ -n "$SUBNAME_SUFFIX" ]] && SUBNAME="${SUBNAME}-${SUBNAME_SUFFIX}"
-
             echo "subname=$SUBNAME" >> "$GITHUB_OUTPUT"
             echo "domain=${SUBNAME}.${BASENAME}" >> "$GITHUB_OUTPUT"
             echo "fqdn=${SUBNAME}.${BASENAME}.dot" >> "$GITHUB_OUTPUT"
@@ -192,7 +180,6 @@ jobs:
           MODE: ${{ inputs.mode }}
           BASENAME: ${{ inputs.basename }}
           SUBNAME_FORMAT: ${{ inputs.subname-format }}
-          SUBNAME_SUFFIX: ${{ inputs.subname-suffix }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.head_ref }}
           COMMIT_SHA: ${{ github.sha }}

--- a/examples/deploy/site/README.md
+++ b/examples/deploy/site/README.md
@@ -38,7 +38,6 @@ All inputs accepted by the reusable `deploy.yml` workflow:
 | `artifact-name` | *(required)* | Name of the uploaded build artifact |
 | `mode` | `preview` | `preview` (subname deploy) or `production` (basename deploy) |
 | `subname-format` | `pr-number` | `pr-number`, `branch`, or `sha-short` (ignored in production mode) |
-| `subname-suffix` | | Optional suffix to avoid store key collisions across base domains |
 | `register-base` | `false` | Register base domain if not already owned |
 | `key-uri` | | Substrate key URI for dev/test (e.g. `//Alice`) |
 | `bulletin-rpc` | CLI default | Bulletin chain WebSocket RPC endpoint override |


### PR DESCRIPTION
Undoing hack suffix hack from https://github.com/paritytech/dotns-sdk/pull/12 The [underlying subname issue](https://github.com/paritytech/dotns/issues/51) has been fixed (https://github.com/paritytech/dotns/pull/48/changes#diff-0f6b3347001b943959ded58452c49f4e78409d76265b8289261aa6636044edd7R138).

## Description

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [x] Chore

## Package

- [ ] `@dotns/cli`
- [x] Root/monorepo
- [ ] Documentation

## Related Issues

## Fixes 

## Checklist

### Documentation

- [x] README updated if needed
- [ ] Types updated if needed

### Breaking Changes

- [ ] No breaking changes
- [x] Breaking changes documented below

**Breaking changes:**

subname suffix is no longer used in the workflow. Only impacts `mark3t` with the relevant PR in place at https://github.com/paritytech/mark3t/pull/174

## Testing

How to test:

1. 
2. 

## Notes