### PR TITLE
fix: Pined bun-version on deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.2.6'
+          bun-version: latest
 
       - name: Download build artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Description

Pin `bun-version` to `latest` instead of `v1.2.6`

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [x] Chore

See: https://github.com/paritytech/dotns-search-bar/actions/runs/23335375778/job/67929501735