### PR TITLE
feat: Set use-car to default to true in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ on:
         description: 'Merkleize with IPFS CLI and upload as a single CAR file'
         required: false
         type: boolean
-        default: false
+        default: true
 
       key-uri:
         description: 'Substrate key URI for dev/test (e.g., //Alice)'


### PR DESCRIPTION
This seems to be the way things going. This should simplify usage for people.

## Description

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Documentation
- [x] Chore

## Package

- [ ] `@dotns/cli`
- [x] Root/monorepo
- [ ] Documentation

## Related Issues

## Fixes 

## Checklist

### Code

- [x] Follows project style
- [x] `bun run lint` passes
- [x] `bun run format` passes
- [x] `bun run typecheck` passes

### Documentation

- [ ] README updated if needed
- [ ] Types updated if needed

### Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

**Breaking changes:**

Default behaviour of the deploy workflow changes. This won't break anything with dotli right now, but could break for anyone expecting to use public ipfs gateways directly.