### PR TITLE
chore(sdk): bump both cli and ui versions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dotns/cli",
   "module": "index.ts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "private": true,
   "packageManager": "bun@1.2.6",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotns-ui",
-  "version": "1.0.0",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.2.6",


### PR DESCRIPTION
## Description

Bump `@dotns/cli` version from `0.4.5` to `0.5.2` and `dotns-ui` version from `1.0.0` to `0.5.2` to align package versions for release.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [x] Chore

## Package

- [x] `@dotns/cli`
- [ ] Root/monorepo
- [ ] Documentation

## Related Issues

N/A

## Fixes

N/A

## Checklist

### Code

- [x] Follows project style
- [x] `bun run lint` passes
- [x] `bun run format` passes
- [x] `bun run typecheck` passes

### Documentation

- [x] README updated if needed
- [x] Types updated if needed

### Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

**Breaking changes:**
N/A

## Testing

How to test:

1. Verify `packages/cli/package.json` shows version `0.5.2`
2. Verify `packages/ui/package.json` shows version `0.5.2`

## Notes

Aligns CLI and UI package versions to `0.5.2` ahead of release. The UI version was corrected from `1.0.0` to match the CLI versioning scheme.