### PR TITLE
chore(ci): dispatch npm release explicitly + allow manual dispatching with any release

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,22 +1,33 @@
 name: NPM Release
 
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.5.2)"
+        required: true
+        type: string
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # When dispatched automatically from release.yml, the release assets
+      # may not be available yet (GitHub processes uploads asynchronously).
+      # Retry up to 5 times with 15s delay to handle this race condition.
       - name: Download CLI tarball from release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p packs
-          gh release download "${{ github.event.release.tag_name }}" \
-            --pattern "*.tgz" \
-            --dir packs \
-            --repo "${{ github.repository }}"
+          for i in 1 2 3 4 5; do
+            gh release download "${{ inputs.tag }}" \
+              --pattern "*.tgz" \
+              --dir packs \
+              --repo "${{ github.repository }}" && break
+            echo "Attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
           ls -ltr packs
 
       - name: Upload packages artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
       - ".github/workflows/release.yml"
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -412,6 +413,12 @@ jobs:
           body_path: release-body.md
           generate_release_notes: true
           prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
+
+      - name: Trigger NPM Release
+        if: needs.build.outputs.prerelease != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run npm-release.yml --ref main -f "tag=${{ needs.build.outputs.tag }}"
 
   deploy-production:
     name: Deploy Production


### PR DESCRIPTION
## Description
Fixes the npm publishing process

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Chore

## Package

- [x] `@dotns/cli`
- [ ] Root/monorepo
- [ ] Documentation

## Related Issues

## Fixes 
Explicit workflow trigger after release + manual dispatch with custom version

## Checklist

### Code

- [ ] Follows project style
- [ ] `bun run lint` passes
- [ ] `bun run format` passes
- [ ] `bun run typecheck` passes

### Documentation

- [ ] README updated if needed
- [ ] Types updated if needed

### Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below
