### PR TITLE
fix(cli): benchmark workflow and action

### DIFF
--- a/.github/actions/setup-cli/action.yml
+++ b/.github/actions/setup-cli/action.yml
@@ -1,5 +1,5 @@
 name: Setup CLI
-description: Install the DotNS CLI from the latest release or from source
+description: Install the DotNS CLI from npm, GitHub release tarball, or from source
 
 inputs:
   source:
@@ -10,12 +10,20 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Download latest CLI release
-      id: download
+    - name: Install CLI from npm
+      id: npm-install
       if: inputs.source == 'release'
+      continue-on-error: true
+      shell: bash
+      run: npm install -g @parity/dotns-cli
+
+    - name: Download CLI release tarball (fallback)
+      id: download
+      if: inputs.source == 'release' && steps.npm-install.outcome != 'success'
       shell: bash
       run: |
         set -euo pipefail
+        echo "::warning::npm install failed, falling back to GitHub release tarball"
         RELEASE_DIR="${RUNNER_TEMP}/dotns-cli-release"
         rm -rf "$RELEASE_DIR"
         mkdir -p "$RELEASE_DIR"
@@ -25,7 +33,7 @@ runs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             https://api.github.com/repos/paritytech/dotns-sdk/releases/latest |
-            jq -r '.assets[] | select(.name | test("^parity-dotns-cli-.*\\.tgz$")) | .url' |
+            jq -r '.assets[] | select(.name | test("dotns-cli.*\\.tgz$")) | .url' |
             head -n 1
         )
 
@@ -41,7 +49,7 @@ runs:
           "$ASSET_URL" \
           -o "$TARBALL_PATH"
 
-        echo "tarball=${TARBALL_PATH}" >> "$GITHUB_OUTPUT"
+        npm install -g "$TARBALL_PATH"
       env:
         GH_TOKEN: ${{ github.token }}
 
@@ -82,11 +90,6 @@ runs:
       run: |
         TARBALL=$(npm pack | tail -n 1)
         echo "tarball=${PWD}/${TARBALL}" >> "$GITHUB_OUTPUT"
-
-    - name: Install released CLI
-      if: inputs.source == 'release'
-      shell: bash
-      run: npm install -g "${{ steps.download.outputs.tarball }}"
 
     - name: Install built CLI
       if: inputs.source == 'source'

--- a/.github/workflows/benchmark-on-demand.yml
+++ b/.github/workflows/benchmark-on-demand.yml
@@ -97,6 +97,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Description

Fix two CI benchmark workflow failures:
1. Setup CLI now installs from npm (`@parity/dotns-cli`) by default, with GitHub release tarball as fallback
2. Add missing Node.js 22 setup to the `authorize` job in `benchmark-on-demand.yml`, fixing "Missing WebSocket class" error from `polkadot-api/ws-provider`

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Chore

## Package

- [ ] `@parity/dotns-cli`
- [x] Root/monorepo
- [ ] Documentation

## Related Issues

- https://github.com/paritytech/dotns-sdk/actions/runs/23924650154/job/69778732217
- https://github.com/paritytech/dotns-sdk/actions/runs/23905951058/job/69721234280

## Fixes

- Daily deploy sized benchmarks failing at "Setup CLI" step
- On-demand benchmark failing at "Re-authorise Bulletin account" with `Missing WebSocket class`

## Checklist

### Code

- [x] Follows project style
- [x] `bun run lint` passes
- [x] `bun run format` passes
- [x] `bun run typecheck` passes

### Documentation

- [x] README updated if needed
- [x] Types updated if needed

### Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

**Breaking changes:**

## Testing

How to test:

1. Trigger an on-demand benchmark via issue label — the `authorize` job should pass without "Missing WebSocket class"
2. Wait for or manually trigger the daily deploy sized benchmarks — Setup CLI should install from npm successfully

## Notes

- The setup-cli action now tries `npm install -g @parity/dotns-cli` first, falling back to the GitHub release tarball if npm fails
- The `authorize` job was the only workflow missing `setup-node@v4` with `node-version: "22"` — all other workflows (`deploy.yml`, `daily-deploy-sized-benchmarks.yml`) already had it