### PR TITLE
feat(cli): add --json output to register, content, and pop commands

### DIFF
--- a/packages/cli/src/cli/commands/content.ts
+++ b/packages/cli/src/cli/commands/content.ts
@@ -4,7 +4,8 @@ import type { CommandOptions } from "../../types/types";
 import { viewDomainContentHash, setDomainContentHash } from "../../commands/contentHash";
 import { addAuthOptions } from "./authOptions";
 import { prepareContext } from "../context";
-import { prepareReadOnlyContext } from "./lookup";
+import { prepareReadOnlyContext, getJsonFlag } from "./lookup";
+import { maybeQuiet } from "./bulletin";
 import { formatErrorMessage } from "../../utils/formatting";
 import ora from "ora";
 
@@ -42,23 +43,38 @@ export function attachContentCommands(root: Command) {
 
   const viewContentCommand = contentCommand
     .command("view <name>")
-    .description("View domain content hash");
+    .description("View domain content hash")
+    .option("--json", "Output result as JSON (suppresses all other output)", false);
   addAuthOptions(viewContentCommand).action(
     async (name: string, options: ContentViewOptions, command: Command) => {
+      const jsonOutput = getJsonFlag(command);
       try {
         const mergedOptions = getMergedOptions(command, options);
 
-        const context = await prepareReadOnlyContext(mergedOptions as any);
+        const context = await maybeQuiet(jsonOutput, () =>
+          prepareReadOnlyContext(mergedOptions as any),
+        );
 
-        console.log(chalk.bold("\n▶ Content View\n"));
+        if (!jsonOutput) console.log(chalk.bold("\n▶ Content View\n"));
         const spinner = ora();
 
-        await viewDomainContentHash(context.clientWrapper!, context.account.address, name, spinner);
+        const result = await maybeQuiet(jsonOutput, () =>
+          viewDomainContentHash(context.clientWrapper!, context.account.address, name, spinner),
+        );
 
-        console.log(chalk.green("\n✓ Complete\n"));
+        if (jsonOutput) {
+          process.stdout.write(JSON.stringify(result) + "\n");
+        } else {
+          console.log(chalk.green("\n✓ Complete\n"));
+        }
         process.exit(0);
       } catch (error) {
-        console.error(chalk.red(`\n✗ Error: ${formatErrorMessage(error)}\n`));
+        const errorMessage = formatErrorMessage(error);
+        if (jsonOutput) {
+          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          process.exit(1);
+        }
+        console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
         process.exit(1);
       }
     },
@@ -66,10 +82,12 @@ export function attachContentCommands(root: Command) {
 
   const setContentCommand = contentCommand
     .command("set <name> <cid>")
-    .description("Set domain content hash (IPFS CID)");
+    .description("Set domain content hash (IPFS CID)")
+    .option("--json", "Output result as JSON (suppresses all other output)", false);
 
   addAuthOptions(setContentCommand).action(
     async (name: string, cid: string, options: ContentSetOptions, command: Command) => {
+      const jsonOutput = getJsonFlag(command);
       try {
         const mergedOptions = getMergedOptions(command, options);
 
@@ -77,24 +95,37 @@ export function attachContentCommands(root: Command) {
           throw new Error("Cannot specify both --mnemonic and --key-uri");
         }
 
-        const context = await prepareContext({ ...mergedOptions, useRevive: true });
-
-        console.log(chalk.bold("\n▶ Content Set\n"));
-        const spinner = ora();
-
-        await setDomainContentHash(
-          context.clientWrapper!,
-          context.substrateAddress,
-          context.signer,
-          name,
-          cid,
-          spinner,
+        const context = await maybeQuiet(jsonOutput, () =>
+          prepareContext({ ...mergedOptions, useRevive: true }),
         );
 
-        console.log(chalk.green("\n✓ Complete\n"));
+        if (!jsonOutput) console.log(chalk.bold("\n▶ Content Set\n"));
+        const spinner = ora();
+
+        const result = await maybeQuiet(jsonOutput, () =>
+          setDomainContentHash(
+            context.clientWrapper!,
+            context.substrateAddress,
+            context.signer,
+            name,
+            cid,
+            spinner,
+          ),
+        );
+
+        if (jsonOutput) {
+          process.stdout.write(JSON.stringify(result) + "\n");
+        } else {
+          console.log(chalk.green("\n✓ Complete\n"));
+        }
         process.exit(0);
       } catch (error) {
-        console.error(chalk.red(`\n✗ Error: ${formatErrorMessage(error)}\n`));
+        const errorMessage = formatErrorMessage(error);
+        if (jsonOutput) {
+          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          process.exit(1);
+        }
+        console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
         process.exit(1);
       }
     },

--- a/packages/cli/src/cli/commands/pop.ts
+++ b/packages/cli/src/cli/commands/pop.ts
@@ -10,7 +10,8 @@ import { addAuthOptions } from "./authOptions";
 import type { CommandOptions } from "../../types/types";
 import { formatErrorMessage } from "../../utils/formatting";
 import { ProofOfPersonhoodStatus } from "../../types/types";
-import { prepareReadOnlyContext } from "./lookup";
+import { prepareReadOnlyContext, getJsonFlag } from "./lookup";
+import { maybeQuiet } from "./bulletin";
 import type { Address } from "viem";
 
 export type PopInfoResult = {
@@ -61,50 +62,91 @@ export function attachPopCommands(root: Command): void {
 
   const setPopCommand = popCommand
     .command("set <status>")
-    .description("Set ProofOfPersonhood status (none, lite, or full)");
+    .description("Set ProofOfPersonhood status (none, lite, or full)")
+    .option("--json", "Output result as JSON (suppresses all other output)", false);
 
   addAuthOptions(setPopCommand).action(
     async (status: string, options: CommandOptions, command: Command) => {
+      const jsonOutput = getJsonFlag(command);
       try {
         const mergedOptions = getMergedOptions(command, options);
-        const context = await prepareContext(mergedOptions);
+        const context = await maybeQuiet(jsonOutput, () => prepareContext(mergedOptions));
 
         const parsedStatus = parseProofOfPersonhoodStatus(status);
 
-        await setUserProofOfPersonhoodStatus(
-          context.clientWrapper!,
-          context.substrateAddress,
-          context.signer,
-          context.evmAddress!,
-          "",
-          parsedStatus,
+        await maybeQuiet(jsonOutput, () =>
+          setUserProofOfPersonhoodStatus(
+            context.clientWrapper!,
+            context.substrateAddress,
+            context.signer,
+            context.evmAddress!,
+            "",
+            parsedStatus,
+          ),
         );
 
-        console.log(chalk.green("\n✓ PoP Status Updated\n"));
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({
+              ok: true,
+              status: ProofOfPersonhoodStatus[parsedStatus].toLowerCase(),
+              statusCode: parsedStatus,
+            }) + "\n",
+          );
+        } else {
+          console.log(chalk.green("\n✓ PoP Status Updated\n"));
+        }
         process.exit(0);
       } catch (error) {
-        console.error(chalk.red(`\n✗ Error: ${formatErrorMessage(error)}\n`));
+        const errorMessage = formatErrorMessage(error);
+        if (jsonOutput) {
+          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          process.exit(1);
+        }
+        console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
         process.exit(1);
       }
     },
   );
 
-  const infoCommand = popCommand.command("info").description("Display ProofOfPersonhood status");
+  const infoCommand = popCommand
+    .command("info")
+    .description("Display ProofOfPersonhood status")
+    .option("--json", "Output result as JSON (suppresses all other output)", false);
 
   addAuthOptions(infoCommand).action(async (options: CommandOptions, command: Command) => {
+    const jsonOutput = getJsonFlag(command);
     try {
       const mergedOptions = getMergedOptions(command, options);
-      const info = await readPopInfo(mergedOptions);
+      const info = await maybeQuiet(jsonOutput, () => readPopInfo(mergedOptions));
 
-      console.log(chalk.bold("\n📋 ProofOfPersonhood Status\n"));
-      console.log(chalk.gray("  substrate: ") + chalk.white(info.substrate));
-      console.log(chalk.gray("  evm:       ") + chalk.white(info.evm));
-      console.log(chalk.gray("  status:    ") + chalk.white(ProofOfPersonhoodStatus[info.status]));
-      console.log(chalk.green("\n✓ PoP Status Retrieved\n"));
+      if (jsonOutput) {
+        process.stdout.write(
+          JSON.stringify({
+            substrate: info.substrate,
+            evm: info.evm,
+            status: ProofOfPersonhoodStatus[info.status].toLowerCase(),
+            statusCode: info.status,
+          }) + "\n",
+        );
+      } else {
+        console.log(chalk.bold("\n📋 ProofOfPersonhood Status\n"));
+        console.log(chalk.gray("  substrate: ") + chalk.white(info.substrate));
+        console.log(chalk.gray("  evm:       ") + chalk.white(info.evm));
+        console.log(
+          chalk.gray("  status:    ") + chalk.white(ProofOfPersonhoodStatus[info.status]),
+        );
+        console.log(chalk.green("\n✓ PoP Status Retrieved\n"));
+      }
 
       process.exit(0);
     } catch (error) {
-      console.error(chalk.red(`\n✗ Error: ${formatErrorMessage(error)}\n`));
+      const errorMessage = formatErrorMessage(error);
+      if (jsonOutput) {
+        process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+        process.exit(1);
+      }
+      console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
       process.exit(1);
     }
   });

--- a/packages/cli/src/cli/commands/register.ts
+++ b/packages/cli/src/cli/commands/register.ts
@@ -77,7 +77,24 @@ export function isValidTransferDestination(destination: string): boolean {
   );
 }
 
-export async function executeRegistration(options: Partial<RegisterActionOptions> = {}) {
+export type DomainRegistrationResult = {
+  ok: true;
+  label: string;
+  domain: string;
+  owner: string;
+};
+
+export type SubnameRegistrationResult = {
+  ok: true;
+  label: string;
+  parent: string;
+  domain: string;
+  owner: string;
+};
+
+export async function executeRegistration(
+  options: Partial<RegisterActionOptions> = {},
+): Promise<DomainRegistrationResult | SubnameRegistrationResult> {
   if (options.mnemonic && options.keyUri) {
     throw new Error("Cannot specify both --mnemonic and --key-uri");
   }
@@ -152,11 +169,13 @@ export async function executeRegistration(options: Partial<RegisterActionOptions
   console.log(`${chalk.bold.green("         ✓ Operation Complete          ")}`);
   console.log(`${chalk.bold.green("═══════════════════════════════════════")}\n`);
   console.log(chalk.gray("  Domain: ") + chalk.cyan(label + ".dot"));
+
+  return { ok: true as const, label, domain: `${label}.dot`, owner: evmAddress };
 }
 
 export async function executeSubnameRegistration(
   options: Partial<RegisterActionOptions>,
-): Promise<void> {
+): Promise<SubnameRegistrationResult> {
   if (!options.name) {
     throw new Error("Missing subname: use --name <sublabel>");
   }
@@ -196,6 +215,14 @@ export async function executeSubnameRegistration(
   console.log(`${chalk.bold.green("         ✓ Subname Registered          ")}`);
   console.log(`${chalk.bold.green("═══════════════════════════════════════")}\n`);
   console.log(chalk.gray("  Domain: ") + chalk.cyan(fullName));
+
+  return {
+    ok: true as const,
+    label: sublabel,
+    parent: parentLabel,
+    domain: fullName,
+    owner: ownerAddress,
+  };
 }
 
 async function executeGovernanceRegistration(

--- a/packages/cli/src/cli/commands/registerCommand.ts
+++ b/packages/cli/src/cli/commands/registerCommand.ts
@@ -5,6 +5,8 @@ import { type RegistrationCommandOptions } from "../../types/types";
 import { addAuthOptions, getAuthOptions } from "./authOptions";
 import { formatErrorMessage } from "../../utils/formatting";
 import { DEFAULT_COMMITMENT_BUFFER_SECONDS } from "../../utils/constants";
+import { getJsonFlag } from "./lookup";
+import { maybeQuiet } from "./bulletin";
 
 export type RegisterActionOptions = RegistrationCommandOptions & {
   __statusProvided?: boolean;
@@ -41,7 +43,9 @@ export function attachRegisterCommand(root: Command) {
       "--cb, --commitment-buffer <seconds>",
       `Extra seconds to wait after minCommitmentAge (default: ${DEFAULT_COMMITMENT_BUFFER_SECONDS}, env: DOTNS_COMMITMENT_BUFFER)`,
     )
+    .option("--json", "Output result as JSON (suppresses all other output)", false)
     .action(async (options: RegistrationCommandOptions, cmd: any) => {
+      const jsonOutput = getJsonFlag(cmd);
       try {
         const merged = { ...options, ...getAuthOptions(cmd) } as RegisterActionOptions;
 
@@ -55,10 +59,19 @@ export function attachRegisterCommand(root: Command) {
           throw new Error("Missing transfer destination: use --to <evm|ss58|label>");
         }
 
-        await executeRegistration(merged);
+        const result = await maybeQuiet(jsonOutput, () => executeRegistration(merged));
+
+        if (jsonOutput) {
+          process.stdout.write(JSON.stringify(result) + "\n");
+        }
         process.exit(0);
       } catch (error) {
-        console.error(`\n${chalk.red.bold("✗ Error:")} ${formatErrorMessage(error)}\n`);
+        const errorMessage = formatErrorMessage(error);
+        if (jsonOutput) {
+          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          process.exit(1);
+        }
+        console.error(`\n${chalk.red.bold("✗ Error:")} ${errorMessage}\n`);
         process.exit(1);
       }
     });
@@ -71,14 +84,25 @@ export function attachRegisterCommand(root: Command) {
     .requiredOption("-n, --name <label>", "Subname label to register")
     .requiredOption("-p, --parent <label>", "Parent domain label (without .dot)")
     .option("-o, --owner <address>", "Owner address (EVM or Substrate, or label)")
+    .option("--json", "Output result as JSON (suppresses all other output)", false)
     .action(async (options: any, cmd: any) => {
+      const jsonOutput = getJsonFlag(cmd);
       try {
         const merged = { ...options, ...getAuthOptions(cmd) } as RegisterActionOptions;
 
-        await executeSubnameRegistration(merged);
+        const result = await maybeQuiet(jsonOutput, () => executeSubnameRegistration(merged));
+
+        if (jsonOutput) {
+          process.stdout.write(JSON.stringify(result) + "\n");
+        }
         process.exit(0);
       } catch (error) {
-        console.error(`\n${chalk.red.bold("✗ Error:")} ${formatErrorMessage(error)}\n`);
+        const errorMessage = formatErrorMessage(error);
+        if (jsonOutput) {
+          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          process.exit(1);
+        }
+        console.error(`\n${chalk.red.bold("✗ Error:")} ${errorMessage}\n`);
         process.exit(1);
       }
     });

--- a/packages/cli/src/commands/contentHash.ts
+++ b/packages/cli/src/commands/contentHash.ts
@@ -22,12 +22,26 @@ function encodeCidToContenthash(cidString: string): Hex {
   return `0x${encoded}` as Hex;
 }
 
+export type ContentViewResult = {
+  domain: string;
+  contenthash: string | null;
+  cid: string | null;
+};
+
+export type ContentSetResult = {
+  ok: true;
+  domain: string;
+  cid: string;
+  contenthash: string;
+  txHash: string;
+};
+
 export async function viewDomainContentHash(
   clientWrapper: ReviveClientWrapper,
   originSubstrateAddress: string,
   label: string,
   spinner: Ora,
-): Promise<void> {
+): Promise<ContentViewResult> {
   const namehashNode = namehash(`${label}.dot`);
   spinner.start("Querying registry");
 
@@ -60,7 +74,7 @@ export async function viewDomainContentHash(
 
   if (!recordExists || ownerAddress === zeroAddress) {
     console.log(chalk.yellow("  status: Domain not registered"));
-    return;
+    return { domain: `${label}.dot`, contenthash: null, cid: null };
   }
 
   const contentHashBytes = await performContractCall<Hex>(
@@ -77,6 +91,13 @@ export async function viewDomainContentHash(
   console.log(chalk.gray("  resolver:    ") + chalk.white(CONTRACTS.DOTNS_CONTENT_RESOLVER));
   console.log(chalk.gray("  contenthash: ") + chalk.white(contentHashBytes));
   console.log(chalk.gray("  cid:         ") + chalk.cyan(decodedCid));
+
+  const hasContent = contentHashBytes !== "0x" && contentHashBytes !== "0x0" && contentHashBytes.length >= 6;
+  return {
+    domain: `${label}.dot`,
+    contenthash: hasContent ? contentHashBytes : null,
+    cid: hasContent && decodedCid !== `Unable to decode: ${contentHashBytes}` ? decodedCid : null,
+  };
 }
 
 export async function setDomainContentHash(
@@ -86,7 +107,7 @@ export async function setDomainContentHash(
   label: string,
   contentId: string,
   spinner: Ora,
-): Promise<void> {
+): Promise<ContentSetResult> {
   const namehashNode = namehash(`${label}.dot`);
 
   console.log(chalk.gray("  domain: ") + chalk.cyan(`${label}.dot`));
@@ -165,4 +186,12 @@ export async function setDomainContentHash(
 
   console.log();
   console.log(chalk.gray("  new: ") + chalk.cyan(updatedCid));
+
+  return {
+    ok: true as const,
+    domain: `${label}.dot`,
+    cid: contentId,
+    contenthash: contentBytes,
+    txHash: transactionHash,
+  };
 }


### PR DESCRIPTION
## Summary

- Add `--json` flag to **register domain**, **register subname**, **content set**, **content view**, **pop set**, and **pop info** commands
- Follows the exact pattern already used by `bulletin` and `lookup` commands: `maybeQuiet()` suppresses human-readable output, structured JSON is written to stdout, errors go to stderr
- The underlying `viewDomainContentHash` and `setDomainContentHash` functions now return result objects (backward compatible -- callers that ignored the `void` return still work)
- Registration functions (`executeRegistration`, `executeSubnameRegistration`) now return result objects with label, domain, and owner

## Motivation

Tools like [bulletin-deploy](https://github.com/paritytech/bulletin-deploy) need to programmatically parse CIDs, tx hashes, and status from CLI output. Without `--json`, they must resort to fragile regex parsing of human-readable output that can break when formatting changes.

## JSON output shapes

| Command | stdout |
|---------|--------|
| `register domain --json` | `{"ok":true,"label":"...","domain":"...dot","owner":"0x..."}` |
| `register subname --json` | `{"ok":true,"label":"...","parent":"...","domain":"...dot","owner":"0x..."}` |
| `content view --json` | `{"domain":"...dot","contenthash":"0x...","cid":"..."}` or `{"domain":"...dot","contenthash":null,"cid":null}` |
| `content set --json` | `{"ok":true,"domain":"...dot","cid":"...","contenthash":"0x...","txHash":"0x..."}` |
| `pop set --json` | `{"ok":true,"status":"full","statusCode":2}` |
| `pop info --json` | `{"substrate":"...","evm":"0x...","status":"full","statusCode":2}` |

On error with `--json`, all commands write `{"error":"..."}` to stderr and exit non-zero.

## Test plan

- [ ] Verify `dotns register domain --json` suppresses human output and prints JSON to stdout
- [ ] Verify `dotns content view <name> --json` returns content hash or null
- [ ] Verify `dotns pop info --json` returns status object
- [ ] Verify error cases with `--json` write to stderr
- [ ] Verify all commands without `--json` behave identically to before (no regressions)