### PR TITLE
feat(cli): add --json output to register, content, and pop commands

### DIFF
--- a/packages/cli/src/cli/commands/auth.ts
+++ b/packages/cli/src/cli/commands/auth.ts
@@ -24,29 +24,11 @@ import type {
 const DEFAULT_ACCOUNT_POINTER_FILE = ".default";
 const KEYSTORE_FILE_EXTENSION = ".json";
 
+import { getMergedOptions } from "./jsonHelpers";
+
 const MNEMONIC_PROMPT = "mnemonic";
 const KEY_URI_PROMPT = "key-uri";
 const AUTH_TYPE_UNKNOWN: AuthType = "unknown";
-
-function getMergedOptions(command: Command | undefined, fallback: CommandOptions): CommandOptions {
-  const mergedOptions: CommandOptions = { ...(fallback ?? {}) };
-
-  let currentCommand: Command | null | undefined = command?.parent;
-  while (currentCommand) {
-    if (typeof currentCommand.opts === "function") {
-      const parentOptions = currentCommand.opts() as CommandOptions;
-      for (const key in parentOptions) {
-        const optionKey = key as keyof CommandOptions;
-        if (!(optionKey in mergedOptions) && parentOptions[optionKey] !== undefined) {
-          mergedOptions[optionKey] = parentOptions[optionKey];
-        }
-      }
-    }
-    currentCommand = currentCommand.parent;
-  }
-
-  return mergedOptions;
-}
 
 function resolvePasswordForCreate(options: CommandOptions): Promise<string> | string {
   const fromCli = String(options.password ?? "").trim();

--- a/packages/cli/src/cli/commands/bulletin.ts
+++ b/packages/cli/src/cli/commands/bulletin.ts
@@ -10,7 +10,6 @@ import type {
   BulletinReporterMode,
   BulletinRetryHandler,
   BulletinUploadOptions,
-  CommandOptions,
   UploadProfiler,
   UploadProfilerOptions,
   UploadProfileReport,
@@ -68,7 +67,7 @@ import {
   DEFAULT_AUTHORIZATION_TRANSACTIONS,
   DEFAULT_AUTHORIZATION_BYTES,
 } from "../../utils/constants";
-import { getJsonFlag } from "./lookup";
+import { getJsonFlag, getMergedOptions, withCapturedConsole } from "./jsonHelpers";
 import { clampChunkSizeBytes } from "../../bulletin/store";
 import {
   createCliReporter,
@@ -78,28 +77,6 @@ import {
   type ReporterTask,
   type ResolvedReporterMode,
 } from "../reporter";
-
-function getMergedOptions(
-  command: Command | undefined,
-  fallback: BulletinUploadOptions,
-): CommandOptions & BulletinUploadOptions {
-  const mergedOptions: any = { ...(fallback ?? {}) };
-
-  let currentCommand: Command | null | undefined = command?.parent;
-  while (currentCommand) {
-    if (typeof currentCommand.opts === "function") {
-      const parentOptions = currentCommand.opts();
-      for (const key in parentOptions) {
-        if (!(key in mergedOptions) && parentOptions[key] !== undefined) {
-          mergedOptions[key] = parentOptions[key];
-        }
-      }
-    }
-    currentCommand = currentCommand.parent;
-  }
-
-  return mergedOptions;
-}
 
 const PROFILE_SAMPLE_INTERVAL_MS = 2_000;
 
@@ -234,58 +211,6 @@ export function createUploadProfiler(options: UploadProfilerOptions): UploadProf
     },
     finalize: summarizeAndWrite,
   };
-}
-
-export async function withCapturedConsole<T>(callback: () => Promise<T>): Promise<T> {
-  const MAX_CAPTURED_ENTRIES = 400;
-  const captured: string[] = [];
-  const pushCaptured = (value: string) => {
-    captured.push(value);
-    if (captured.length > MAX_CAPTURED_ENTRIES) {
-      captured.splice(0, captured.length - MAX_CAPTURED_ENTRIES);
-    }
-  };
-  const capture = (...args: any[]) => {
-    pushCaptured(args.map(String).join(" "));
-  };
-  const captureWrite = (chunk: any) => {
-    pushCaptured(String(chunk));
-    return true;
-  };
-
-  const saved = {
-    log: console.log,
-    error: console.error,
-    warn: console.warn,
-    info: console.info,
-    stdoutWrite: process.stdout.write.bind(process.stdout),
-    stderrWrite: process.stderr.write.bind(process.stderr),
-  };
-
-  console.log = capture;
-  console.error = capture;
-  console.warn = capture;
-  console.info = capture;
-  process.stdout.write = captureWrite as any;
-  process.stderr.write = captureWrite as any;
-
-  try {
-    return await callback();
-  } catch (error) {
-    saved.error("[captured output before failure]\n" + captured.join("\n"));
-    throw error;
-  } finally {
-    console.log = saved.log;
-    console.error = saved.error;
-    console.warn = saved.warn;
-    console.info = saved.info;
-    process.stdout.write = saved.stdoutWrite;
-    process.stderr.write = saved.stderrWrite;
-  }
-}
-
-export function maybeQuiet<T>(jsonOutput: boolean, callback: () => Promise<T>): Promise<T> {
-  return jsonOutput ? withCapturedConsole(callback) : callback();
 }
 
 async function withBulletinHumanOutput<T>(

--- a/packages/cli/src/cli/commands/content.ts
+++ b/packages/cli/src/cli/commands/content.ts
@@ -6,7 +6,7 @@ import { addAuthOptions } from "./authOptions";
 import { prepareContext } from "../context";
 import { prepareReadOnlyContext, getJsonFlag } from "./lookup";
 import { maybeQuiet } from "./bulletin";
-import { formatErrorMessage } from "../../utils/formatting";
+import { emitJsonResult, handleCommandError } from "./jsonHelpers";
 import ora from "ora";
 
 export interface ContentViewOptions {
@@ -65,20 +65,12 @@ export function attachContentCommands(root: Command) {
           viewDomainContentHash(context.clientWrapper!, context.account.address, name, spinner),
         );
 
-        if (jsonOutput) {
-          console.log(JSON.stringify(result));
-        } else {
+        if (!emitJsonResult(jsonOutput, result)) {
           console.log(chalk.green("\n✓ Complete\n"));
         }
         process.exit(0);
       } catch (error) {
-        const errorMessage = formatErrorMessage(error);
-        if (jsonOutput) {
-          console.error(JSON.stringify({ error: errorMessage }));
-          process.exit(1);
-        }
-        console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
-        process.exit(1);
+        handleCommandError(jsonOutput, error);
       }
     },
   );
@@ -117,20 +109,12 @@ export function attachContentCommands(root: Command) {
           ),
         );
 
-        if (jsonOutput) {
-          console.log(JSON.stringify(result));
-        } else {
+        if (!emitJsonResult(jsonOutput, result)) {
           console.log(chalk.green("\n✓ Complete\n"));
         }
         process.exit(0);
       } catch (error) {
-        const errorMessage = formatErrorMessage(error);
-        if (jsonOutput) {
-          console.error(JSON.stringify({ error: errorMessage }));
-          process.exit(1);
-        }
-        console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
-        process.exit(1);
+        handleCommandError(jsonOutput, error);
       }
     },
   );

--- a/packages/cli/src/cli/commands/content.ts
+++ b/packages/cli/src/cli/commands/content.ts
@@ -56,6 +56,9 @@ export function attachContentCommands(root: Command) {
         );
 
         if (!jsonOutput) console.log(chalk.bold("\n▶ Content View\n"));
+        // Ora caches process.stderr (the object), not .write (the method).
+        // withCapturedConsole replaces .write on the object, so spinner
+        // output is captured as long as start/succeed/fail run inside maybeQuiet.
         const spinner = ora();
 
         const result = await maybeQuiet(jsonOutput, () =>
@@ -63,7 +66,7 @@ export function attachContentCommands(root: Command) {
         );
 
         if (jsonOutput) {
-          process.stdout.write(JSON.stringify(result) + "\n");
+          console.log(JSON.stringify(result));
         } else {
           console.log(chalk.green("\n✓ Complete\n"));
         }
@@ -71,7 +74,7 @@ export function attachContentCommands(root: Command) {
       } catch (error) {
         const errorMessage = formatErrorMessage(error);
         if (jsonOutput) {
-          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          console.error(JSON.stringify({ error: errorMessage }));
           process.exit(1);
         }
         console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
@@ -100,6 +103,7 @@ export function attachContentCommands(root: Command) {
         );
 
         if (!jsonOutput) console.log(chalk.bold("\n▶ Content Set\n"));
+        // See view handler above for why ora is safe inside maybeQuiet.
         const spinner = ora();
 
         const result = await maybeQuiet(jsonOutput, () =>
@@ -114,7 +118,7 @@ export function attachContentCommands(root: Command) {
         );
 
         if (jsonOutput) {
-          process.stdout.write(JSON.stringify(result) + "\n");
+          console.log(JSON.stringify(result));
         } else {
           console.log(chalk.green("\n✓ Complete\n"));
         }
@@ -122,7 +126,7 @@ export function attachContentCommands(root: Command) {
       } catch (error) {
         const errorMessage = formatErrorMessage(error);
         if (jsonOutput) {
-          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          console.error(JSON.stringify({ error: errorMessage }));
           process.exit(1);
         }
         console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));

--- a/packages/cli/src/cli/commands/content.ts
+++ b/packages/cli/src/cli/commands/content.ts
@@ -4,7 +4,8 @@ import type { CommandOptions } from "../../types/types";
 import { viewDomainContentHash, setDomainContentHash } from "../../commands/contentHash";
 import { addAuthOptions } from "./authOptions";
 import { prepareContext } from "../context";
-import { prepareReadOnlyContext } from "./lookup";
+import { prepareReadOnlyContext, getJsonFlag } from "./lookup";
+import { maybeQuiet } from "./bulletin";
 import { formatErrorMessage } from "../../utils/formatting";
 import ora from "ora";
 
@@ -42,23 +43,38 @@ export function attachContentCommands(root: Command) {
 
   const viewContentCommand = contentCommand
     .command("view <name>")
-    .description("View domain content hash");
+    .description("View domain content hash")
+    .option("--json", "Output result as JSON (suppresses all other output)", false);
   addAuthOptions(viewContentCommand).action(
     async (name: string, options: ContentViewOptions, command: Command) => {
+      const jsonOutput = getJsonFlag(command);
       try {
         const mergedOptions = getMergedOptions(command, options);
 
-        const context = await prepareReadOnlyContext(mergedOptions as any);
+        const context = await maybeQuiet(jsonOutput, () =>
+          prepareReadOnlyContext(mergedOptions as any),
+        );
 
-        console.log(chalk.bold("\n▶ Content View\n"));
+        if (!jsonOutput) console.log(chalk.bold("\n▶ Content View\n"));
         const spinner = ora();
 
-        await viewDomainContentHash(context.clientWrapper!, context.account.address, name, spinner);
+        const result = await maybeQuiet(jsonOutput, () =>
+          viewDomainContentHash(context.clientWrapper!, context.account.address, name, spinner),
+        );
 
-        console.log(chalk.green("\n✓ Complete\n"));
+        if (jsonOutput) {
+          process.stdout.write(JSON.stringify(result) + "\n");
+        } else {
+          console.log(chalk.green("\n✓ Complete\n"));
+        }
         process.exit(0);
       } catch (error) {
-        console.error(chalk.red(`\n✗ Error: ${formatErrorMessage(error)}\n`));
+        const errorMessage = formatErrorMessage(error);
+        if (jsonOutput) {
+          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          process.exit(1);
+        }
+        console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
         process.exit(1);
       }
     },
@@ -66,10 +82,12 @@ export function attachContentCommands(root: Command) {
 
   const setContentCommand = contentCommand
     .command("set <name> <cid>")
-    .description("Set domain content hash (IPFS CID)");
+    .description("Set domain content hash (IPFS CID)")
+    .option("--json", "Output result as JSON (suppresses all other output)", false);
 
   addAuthOptions(setContentCommand).action(
     async (name: string, cid: string, options: ContentSetOptions, command: Command) => {
+      const jsonOutput = getJsonFlag(command);
       try {
         const mergedOptions = getMergedOptions(command, options);
 
@@ -77,24 +95,37 @@ export function attachContentCommands(root: Command) {
           throw new Error("Cannot specify both --mnemonic and --key-uri");
         }
 
-        const context = await prepareContext({ ...mergedOptions, useRevive: true });
-
-        console.log(chalk.bold("\n▶ Content Set\n"));
-        const spinner = ora();
-
-        await setDomainContentHash(
-          context.clientWrapper!,
-          context.substrateAddress,
-          context.signer,
-          name,
-          cid,
-          spinner,
+        const context = await maybeQuiet(jsonOutput, () =>
+          prepareContext({ ...mergedOptions, useRevive: true }),
         );
 
-        console.log(chalk.green("\n✓ Complete\n"));
+        if (!jsonOutput) console.log(chalk.bold("\n▶ Content Set\n"));
+        const spinner = ora();
+
+        const result = await maybeQuiet(jsonOutput, () =>
+          setDomainContentHash(
+            context.clientWrapper!,
+            context.substrateAddress,
+            context.signer,
+            name,
+            cid,
+            spinner,
+          ),
+        );
+
+        if (jsonOutput) {
+          process.stdout.write(JSON.stringify(result) + "\n");
+        } else {
+          console.log(chalk.green("\n✓ Complete\n"));
+        }
         process.exit(0);
       } catch (error) {
-        console.error(chalk.red(`\n✗ Error: ${formatErrorMessage(error)}\n`));
+        const errorMessage = formatErrorMessage(error);
+        if (jsonOutput) {
+          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          process.exit(1);
+        }
+        console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
         process.exit(1);
       }
     },

--- a/packages/cli/src/cli/commands/content.ts
+++ b/packages/cli/src/cli/commands/content.ts
@@ -1,12 +1,16 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import type { CommandOptions } from "../../types/types";
 import { viewDomainContentHash, setDomainContentHash } from "../../commands/contentHash";
 import { addAuthOptions } from "./authOptions";
 import { prepareContext } from "../context";
-import { prepareReadOnlyContext, getJsonFlag } from "./lookup";
-import { maybeQuiet } from "./bulletin";
-import { emitJsonResult, handleCommandError } from "./jsonHelpers";
+import { prepareReadOnlyContext } from "./lookup";
+import {
+  getMergedOptions,
+  getJsonFlag,
+  maybeQuiet,
+  emitJsonResult,
+  handleCommandError,
+} from "./jsonHelpers";
 import ora from "ora";
 
 export interface ContentViewOptions {
@@ -15,25 +19,6 @@ export interface ContentViewOptions {
 
 export interface ContentSetOptions {
   rpc?: string;
-}
-
-function getMergedOptions<T>(command: Command | undefined, fallback: T): CommandOptions & T {
-  const mergedOptions: any = { ...(fallback ?? {}) };
-
-  let currentCommand: Command | null | undefined = command?.parent;
-  while (currentCommand) {
-    if (typeof currentCommand.opts === "function") {
-      const parentOptions = currentCommand.opts();
-      for (const key in parentOptions) {
-        if (!(key in mergedOptions) && parentOptions[key] !== undefined) {
-          mergedOptions[key] = parentOptions[key];
-        }
-      }
-    }
-    currentCommand = currentCommand.parent;
-  }
-
-  return mergedOptions;
 }
 
 export function attachContentCommands(root: Command) {
@@ -56,9 +41,6 @@ export function attachContentCommands(root: Command) {
         );
 
         if (!jsonOutput) console.log(chalk.bold("\n▶ Content View\n"));
-        // Ora caches process.stderr (the object), not .write (the method).
-        // withCapturedConsole replaces .write on the object, so spinner
-        // output is captured as long as start/succeed/fail run inside maybeQuiet.
         const spinner = ora();
 
         const result = await maybeQuiet(jsonOutput, () =>
@@ -95,7 +77,6 @@ export function attachContentCommands(root: Command) {
         );
 
         if (!jsonOutput) console.log(chalk.bold("\n▶ Content Set\n"));
-        // See view handler above for why ora is safe inside maybeQuiet.
         const spinner = ora();
 
         const result = await maybeQuiet(jsonOutput, () =>

--- a/packages/cli/src/cli/commands/info.ts
+++ b/packages/cli/src/cli/commands/info.ts
@@ -11,32 +11,13 @@ import { resolveRpc, resolveKeystorePath } from "../env";
 import { formatErrorMessage } from "../../utils/formatting";
 import { resolveAuthSource, createAccountFromSource } from "../../commands/auth";
 import { step } from "../ui";
-import { getJsonFlag, prepareReadOnlyContext } from "./lookup";
-import { maybeQuiet } from "./bulletin";
+import { prepareReadOnlyContext } from "./lookup";
+import { getJsonFlag, getMergedOptions, maybeQuiet } from "./jsonHelpers";
 import {
   checkAccountMapped,
   checkWhitelisted,
   whitelistAddress,
 } from "../../commands/accountChecks";
-
-function getMergedOptions<T>(command: Command | undefined, fallback: T): CommandOptions & T {
-  const mergedOptions: any = { ...(fallback ?? {}) };
-
-  let currentCommand: Command | null | undefined = command?.parent;
-  while (currentCommand) {
-    if (typeof currentCommand.opts === "function") {
-      const parentOptions = currentCommand.opts();
-      for (const key in parentOptions) {
-        if (!(key in mergedOptions) && parentOptions[key] !== undefined) {
-          mergedOptions[key] = parentOptions[key];
-        }
-      }
-    }
-    currentCommand = currentCommand.parent;
-  }
-
-  return mergedOptions;
-}
 
 export function attachAccountCommands(root: Command) {
   const accountCommand = root.command("account").description("Account management utilities");

--- a/packages/cli/src/cli/commands/jsonHelpers.ts
+++ b/packages/cli/src/cli/commands/jsonHelpers.ts
@@ -1,0 +1,40 @@
+import chalk from "chalk";
+import { formatErrorMessage } from "../../utils/formatting";
+
+/**
+ * Shared helpers for --json output across CLI commands.
+ *
+ * JSON envelope convention:
+ * - Mutations (register, set, etc.) return { ok: true, ...fields }
+ * - Reads (view, info, lookup) return the data directly (no ok field)
+ * - Errors always return { error: "message" } on stderr with exit code 1
+ */
+
+/**
+ * Emit a JSON result to stdout if --json is active.
+ * Returns true if JSON was emitted, false otherwise (so the caller
+ * can provide human-readable output in the else branch).
+ */
+export function emitJsonResult(jsonOutput: boolean, result: unknown): boolean {
+  if (jsonOutput) {
+    console.log(JSON.stringify(result));
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Handle a command error, formatting as JSON or human-readable depending
+ * on the --json flag. Always exits with code 1.
+ */
+export function handleCommandError(jsonOutput: boolean, error: unknown): never {
+  const message = formatErrorMessage(error);
+
+  if (jsonOutput) {
+    console.error(JSON.stringify({ error: message }));
+  } else {
+    console.error(chalk.red(`\n✗ Error: ${message}\n`));
+  }
+
+  process.exit(1);
+}

--- a/packages/cli/src/cli/commands/jsonHelpers.ts
+++ b/packages/cli/src/cli/commands/jsonHelpers.ts
@@ -1,14 +1,56 @@
+import { Command } from "commander";
 import chalk from "chalk";
 import { formatErrorMessage } from "../../utils/formatting";
+import type { CommandOptions } from "../../types/types";
 
 /**
- * Shared helpers for --json output across CLI commands.
+ * Shared helpers for --json output and Commander option merging.
  *
  * JSON envelope convention:
  * - Mutations (register, set, etc.) return { ok: true, ...fields }
  * - Reads (view, info, lookup) return the data directly (no ok field)
  * - Errors always return { error: "message" } on stderr with exit code 1
  */
+
+/**
+ * Walk up the Commander parent chain and merge options from ancestor
+ * commands into a single object. Child options take precedence.
+ */
+export function getMergedOptions<T>(command: Command | undefined, fallback: T): CommandOptions & T {
+  const mergedOptions: any = { ...(fallback ?? {}) };
+
+  let currentCommand: Command | null | undefined = command?.parent;
+  while (currentCommand) {
+    if (typeof currentCommand.opts === "function") {
+      const parentOptions = currentCommand.opts();
+      for (const key in parentOptions) {
+        if (!(key in mergedOptions) && parentOptions[key] !== undefined) {
+          mergedOptions[key] = parentOptions[key];
+        }
+      }
+    }
+    currentCommand = currentCommand.parent;
+  }
+
+  return mergedOptions;
+}
+
+/**
+ * Read the --json flag from a Commander command, checking optsWithGlobals
+ * first (covers parent-level flags), then local opts.
+ */
+export function getJsonFlag(command: any): boolean {
+  if (command && typeof command.optsWithGlobals === "function") {
+    const options = command.optsWithGlobals();
+    if (typeof options?.json === "boolean") return options.json;
+  }
+
+  const localOptions =
+    command && typeof command.opts === "function" ? (command.opts() as any) : undefined;
+  if (typeof localOptions?.json === "boolean") return localOptions.json;
+
+  return false;
+}
 
 /**
  * Emit a JSON result to stdout if --json is active.
@@ -37,4 +79,66 @@ export function handleCommandError(jsonOutput: boolean, error: unknown): never {
   }
 
   process.exit(1);
+}
+
+/**
+ * Capture all console and stream output during a callback, suppressing it.
+ * On error, the captured output is dumped to stderr before re-throwing.
+ */
+export async function withCapturedConsole<T>(callback: () => Promise<T>): Promise<T> {
+  const MAX_CAPTURED_ENTRIES = 400;
+  const captured: string[] = [];
+  const pushCaptured = (value: string) => {
+    captured.push(value);
+    if (captured.length > MAX_CAPTURED_ENTRIES) {
+      captured.splice(0, captured.length - MAX_CAPTURED_ENTRIES);
+    }
+  };
+  const capture = (...args: any[]) => {
+    pushCaptured(args.map(String).join(" "));
+  };
+  const captureWrite = (chunk: any) => {
+    pushCaptured(String(chunk));
+    return true;
+  };
+
+  const saved = {
+    log: console.log,
+    error: console.error,
+    warn: console.warn,
+    info: console.info,
+    stdoutWrite: process.stdout.write.bind(process.stdout),
+    stderrWrite: process.stderr.write.bind(process.stderr),
+  };
+
+  console.log = capture;
+  console.error = capture;
+  console.warn = capture;
+  console.info = capture;
+  process.stdout.write = captureWrite as any;
+  process.stderr.write = captureWrite as any;
+
+  try {
+    return await callback();
+  } catch (error) {
+    saved.error("[captured output before failure]\n" + captured.join("\n"));
+    throw error;
+  } finally {
+    console.log = saved.log;
+    console.error = saved.error;
+    console.warn = saved.warn;
+    console.info = saved.info;
+    process.stdout.write = saved.stdoutWrite;
+    process.stderr.write = saved.stderrWrite;
+  }
+}
+
+/**
+ * When --json is active, suppress human-readable output by capturing it.
+ * Ora caches process.stderr (the object), not .write (the method).
+ * withCapturedConsole replaces .write on the object, so spinner
+ * output is captured as long as start/succeed/fail run inside maybeQuiet.
+ */
+export function maybeQuiet<T>(jsonOutput: boolean, callback: () => Promise<T>): Promise<T> {
+  return jsonOutput ? withCapturedConsole(callback) : callback();
 }

--- a/packages/cli/src/cli/commands/lookup.ts
+++ b/packages/cli/src/cli/commands/lookup.ts
@@ -24,25 +24,12 @@ import type {
   LookupActionOptions,
   ResolvedReadOnlyAuth,
 } from "../../types/types";
-import { maybeQuiet } from "./bulletin";
+import { getJsonFlag, maybeQuiet } from "./jsonHelpers";
 import type { Address } from "viem";
 
 function createClientWrapper(rpc: string) {
   const client = createClient(getWsProvider(rpc)).getTypedApi(paseo);
   return new ReviveClientWrapper(client as PolkadotApiClient);
-}
-
-export function getJsonFlag(command: any): boolean {
-  if (command && typeof (command as any).optsWithGlobals === "function") {
-    const options = (command as any).optsWithGlobals();
-    if (typeof options?.json === "boolean") return options.json;
-  }
-
-  const localOptions =
-    command && typeof command.opts === "function" ? (command.opts() as any) : undefined;
-  if (typeof localOptions?.json === "boolean") return localOptions.json;
-
-  return process.argv.includes("--json");
 }
 
 function hasAnyAuthHint(opts: AuthSource): boolean {

--- a/packages/cli/src/cli/commands/pop.ts
+++ b/packages/cli/src/cli/commands/pop.ts
@@ -10,7 +10,8 @@ import { addAuthOptions } from "./authOptions";
 import type { CommandOptions } from "../../types/types";
 import { formatErrorMessage } from "../../utils/formatting";
 import { ProofOfPersonhoodStatus } from "../../types/types";
-import { prepareReadOnlyContext } from "./lookup";
+import { prepareReadOnlyContext, getJsonFlag } from "./lookup";
+import { maybeQuiet } from "./bulletin";
 import type { Address } from "viem";
 
 export type PopInfoResult = {
@@ -61,50 +62,91 @@ export function attachPopCommands(root: Command): void {
 
   const setPopCommand = popCommand
     .command("set <status>")
-    .description("Set ProofOfPersonhood status (none, lite, or full)");
+    .description("Set ProofOfPersonhood status (none, lite, or full)")
+    .option("--json", "Output result as JSON (suppresses all other output)", false);
 
   addAuthOptions(setPopCommand).action(
     async (status: string, options: CommandOptions, command: Command) => {
+      const jsonOutput = getJsonFlag(command);
       try {
         const mergedOptions = getMergedOptions(command, options);
-        const context = await prepareContext(mergedOptions);
+        const context = await maybeQuiet(jsonOutput, () => prepareContext(mergedOptions));
 
         const parsedStatus = parseProofOfPersonhoodStatus(status);
 
-        await setUserProofOfPersonhoodStatus(
-          context.clientWrapper!,
-          context.substrateAddress,
-          context.signer,
-          context.evmAddress!,
-          "",
-          parsedStatus,
+        await maybeQuiet(jsonOutput, () =>
+          setUserProofOfPersonhoodStatus(
+            context.clientWrapper!,
+            context.substrateAddress,
+            context.signer,
+            context.evmAddress!,
+            "",
+            parsedStatus,
+          ),
         );
 
-        console.log(chalk.green("\n✓ PoP Status Updated\n"));
+        if (jsonOutput) {
+          process.stdout.write(
+            JSON.stringify({
+              ok: true,
+              status: ProofOfPersonhoodStatus[parsedStatus].toLowerCase(),
+              statusCode: parsedStatus,
+            }) + "\n",
+          );
+        } else {
+          console.log(chalk.green("\n✓ PoP Status Updated\n"));
+        }
         process.exit(0);
       } catch (error) {
-        console.error(chalk.red(`\n✗ Error: ${formatErrorMessage(error)}\n`));
+        const errorMessage = formatErrorMessage(error);
+        if (jsonOutput) {
+          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          process.exit(1);
+        }
+        console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
         process.exit(1);
       }
     },
   );
 
-  const infoCommand = popCommand.command("info").description("Display ProofOfPersonhood status");
+  const infoCommand = popCommand
+    .command("info")
+    .description("Display ProofOfPersonhood status")
+    .option("--json", "Output result as JSON (suppresses all other output)", false);
 
   addAuthOptions(infoCommand).action(async (options: CommandOptions, command: Command) => {
+    const jsonOutput = getJsonFlag(command);
     try {
       const mergedOptions = getMergedOptions(command, options);
-      const info = await readPopInfo(mergedOptions);
+      const info = await maybeQuiet(jsonOutput, () => readPopInfo(mergedOptions));
 
-      console.log(chalk.bold("\n📋 ProofOfPersonhood Status\n"));
-      console.log(chalk.gray("  substrate: ") + chalk.white(info.substrate));
-      console.log(chalk.gray("  evm:       ") + chalk.white(info.evm));
-      console.log(chalk.gray("  status:    ") + chalk.white(ProofOfPersonhoodStatus[info.status]));
-      console.log(chalk.green("\n✓ PoP Status Retrieved\n"));
+      if (jsonOutput) {
+        process.stdout.write(
+          JSON.stringify({
+            substrate: info.substrate,
+            evm: info.evm,
+            status: ProofOfPersonhoodStatus[info.status].toLowerCase(),
+            statusCode: info.status,
+          }) + "\n",
+        );
+      } else {
+        console.log(chalk.bold("\n📋 ProofOfPersonhood Status\n"));
+        console.log(chalk.gray("  substrate: ") + chalk.white(info.substrate));
+        console.log(chalk.gray("  evm:       ") + chalk.white(info.evm));
+        console.log(
+          chalk.gray("  status:    ") + chalk.white(ProofOfPersonhoodStatus[info.status]),
+        );
+        console.log(chalk.green("\n✓ PoP Status Retrieved\n"));
+      }
 
       process.exit(0);
     } catch (error) {
-      console.error(chalk.red(`\n✗ Error: ${formatErrorMessage(error)}\n`));
+      const errorMessage = formatErrorMessage(error);
+      if (jsonOutput) {
+        process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+        process.exit(1);
+      }
+      console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
       process.exit(1);
     }
   });

--- a/packages/cli/src/cli/commands/pop.ts
+++ b/packages/cli/src/cli/commands/pop.ts
@@ -8,10 +8,10 @@ import { parseProofOfPersonhoodStatus } from "../labels";
 import { prepareContext } from "../context";
 import { addAuthOptions } from "./authOptions";
 import type { CommandOptions } from "../../types/types";
-import { formatErrorMessage } from "../../utils/formatting";
 import { ProofOfPersonhoodStatus } from "../../types/types";
 import { prepareReadOnlyContext, getJsonFlag } from "./lookup";
 import { maybeQuiet } from "./bulletin";
+import { emitJsonResult, handleCommandError } from "./jsonHelpers";
 import type { Address } from "viem";
 
 export type PopInfoResult = {
@@ -85,26 +85,18 @@ export function attachPopCommands(root: Command): void {
           ),
         );
 
-        if (jsonOutput) {
-          console.log(
-            JSON.stringify({
-              ok: true,
-              status: ProofOfPersonhoodStatus[parsedStatus].toLowerCase(),
-              statusCode: parsedStatus,
-            }),
-          );
-        } else {
+        if (
+          !emitJsonResult(jsonOutput, {
+            ok: true,
+            status: ProofOfPersonhoodStatus[parsedStatus].toLowerCase(),
+            statusCode: parsedStatus,
+          })
+        ) {
           console.log(chalk.green("\n✓ PoP Status Updated\n"));
         }
         process.exit(0);
       } catch (error) {
-        const errorMessage = formatErrorMessage(error);
-        if (jsonOutput) {
-          console.error(JSON.stringify({ error: errorMessage }));
-          process.exit(1);
-        }
-        console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
-        process.exit(1);
+        handleCommandError(jsonOutput, error);
       }
     },
   );
@@ -120,16 +112,14 @@ export function attachPopCommands(root: Command): void {
       const mergedOptions = getMergedOptions(command, options);
       const info = await maybeQuiet(jsonOutput, () => readPopInfo(mergedOptions));
 
-      if (jsonOutput) {
-        console.log(
-          JSON.stringify({
-            substrate: info.substrate,
-            evm: info.evm,
-            status: ProofOfPersonhoodStatus[info.status].toLowerCase(),
-            statusCode: info.status,
-          }),
-        );
-      } else {
+      if (
+        !emitJsonResult(jsonOutput, {
+          substrate: info.substrate,
+          evm: info.evm,
+          status: ProofOfPersonhoodStatus[info.status].toLowerCase(),
+          statusCode: info.status,
+        })
+      ) {
         console.log(chalk.bold("\n📋 ProofOfPersonhood Status\n"));
         console.log(chalk.gray("  substrate: ") + chalk.white(info.substrate));
         console.log(chalk.gray("  evm:       ") + chalk.white(info.evm));
@@ -141,13 +131,7 @@ export function attachPopCommands(root: Command): void {
 
       process.exit(0);
     } catch (error) {
-      const errorMessage = formatErrorMessage(error);
-      if (jsonOutput) {
-        console.error(JSON.stringify({ error: errorMessage }));
-        process.exit(1);
-      }
-      console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
-      process.exit(1);
+      handleCommandError(jsonOutput, error);
     }
   });
 }

--- a/packages/cli/src/cli/commands/pop.ts
+++ b/packages/cli/src/cli/commands/pop.ts
@@ -86,12 +86,12 @@ export function attachPopCommands(root: Command): void {
         );
 
         if (jsonOutput) {
-          process.stdout.write(
+          console.log(
             JSON.stringify({
               ok: true,
               status: ProofOfPersonhoodStatus[parsedStatus].toLowerCase(),
               statusCode: parsedStatus,
-            }) + "\n",
+            }),
           );
         } else {
           console.log(chalk.green("\n✓ PoP Status Updated\n"));
@@ -100,7 +100,7 @@ export function attachPopCommands(root: Command): void {
       } catch (error) {
         const errorMessage = formatErrorMessage(error);
         if (jsonOutput) {
-          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          console.error(JSON.stringify({ error: errorMessage }));
           process.exit(1);
         }
         console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));
@@ -121,13 +121,13 @@ export function attachPopCommands(root: Command): void {
       const info = await maybeQuiet(jsonOutput, () => readPopInfo(mergedOptions));
 
       if (jsonOutput) {
-        process.stdout.write(
+        console.log(
           JSON.stringify({
             substrate: info.substrate,
             evm: info.evm,
             status: ProofOfPersonhoodStatus[info.status].toLowerCase(),
             statusCode: info.status,
-          }) + "\n",
+          }),
         );
       } else {
         console.log(chalk.bold("\n📋 ProofOfPersonhood Status\n"));
@@ -143,7 +143,7 @@ export function attachPopCommands(root: Command): void {
     } catch (error) {
       const errorMessage = formatErrorMessage(error);
       if (jsonOutput) {
-        process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+        console.error(JSON.stringify({ error: errorMessage }));
         process.exit(1);
       }
       console.error(chalk.red(`\n✗ Error: ${errorMessage}\n`));

--- a/packages/cli/src/cli/commands/pop.ts
+++ b/packages/cli/src/cli/commands/pop.ts
@@ -9,9 +9,14 @@ import { prepareContext } from "../context";
 import { addAuthOptions } from "./authOptions";
 import type { CommandOptions } from "../../types/types";
 import { ProofOfPersonhoodStatus } from "../../types/types";
-import { prepareReadOnlyContext, getJsonFlag } from "./lookup";
-import { maybeQuiet } from "./bulletin";
-import { emitJsonResult, handleCommandError } from "./jsonHelpers";
+import { prepareReadOnlyContext } from "./lookup";
+import {
+  getMergedOptions,
+  getJsonFlag,
+  maybeQuiet,
+  emitJsonResult,
+  handleCommandError,
+} from "./jsonHelpers";
 import type { Address } from "viem";
 
 export type PopInfoResult = {
@@ -19,26 +24,6 @@ export type PopInfoResult = {
   evm: string;
   status: ProofOfPersonhoodStatus;
 };
-
-function getMergedOptions(command: Command | undefined, fallback: CommandOptions): CommandOptions {
-  const mergedOptions: CommandOptions = { ...(fallback ?? {}) };
-
-  let currentCommand: Command | null | undefined = command?.parent;
-  while (currentCommand) {
-    if (typeof currentCommand.opts === "function") {
-      const parentOptions = currentCommand.opts() as CommandOptions;
-      for (const key in parentOptions) {
-        const optionKey = key as keyof CommandOptions;
-        if (!(optionKey in mergedOptions) && parentOptions[optionKey] !== undefined) {
-          mergedOptions[optionKey] = parentOptions[optionKey];
-        }
-      }
-    }
-    currentCommand = currentCommand.parent;
-  }
-
-  return mergedOptions;
-}
 
 async function readPopInfo(options: CommandOptions): Promise<PopInfoResult> {
   const context = await prepareReadOnlyContext(options as any);

--- a/packages/cli/src/cli/commands/register.ts
+++ b/packages/cli/src/cli/commands/register.ts
@@ -77,7 +77,24 @@ export function isValidTransferDestination(destination: string): boolean {
   );
 }
 
-export async function executeRegistration(options: Partial<RegisterActionOptions> = {}) {
+export type DomainRegistrationResult = {
+  ok: true;
+  label: string;
+  domain: string;
+  owner: string;
+};
+
+export type SubnameRegistrationResult = {
+  ok: true;
+  label: string;
+  parent: string;
+  domain: string;
+  owner: string;
+};
+
+export async function executeRegistration(
+  options: Partial<RegisterActionOptions> = {},
+): Promise<DomainRegistrationResult | SubnameRegistrationResult> {
   if (options.mnemonic && options.keyUri) {
     throw new Error("Cannot specify both --mnemonic and --key-uri");
   }
@@ -152,11 +169,13 @@ export async function executeRegistration(options: Partial<RegisterActionOptions
   console.log(`${chalk.bold.green("         ✓ Operation Complete          ")}`);
   console.log(`${chalk.bold.green("═══════════════════════════════════════")}\n`);
   console.log(chalk.gray("  Domain: ") + chalk.cyan(label + ".dot"));
+
+  return { ok: true as const, label, domain: `${label}.dot`, owner: evmAddress };
 }
 
 export async function executeSubnameRegistration(
   options: Partial<RegisterActionOptions>,
-): Promise<void> {
+): Promise<SubnameRegistrationResult> {
   if (!options.name) {
     throw new Error("Missing subname: use --name <sublabel>");
   }
@@ -196,6 +215,14 @@ export async function executeSubnameRegistration(
   console.log(`${chalk.bold.green("         ✓ Subname Registered          ")}`);
   console.log(`${chalk.bold.green("═══════════════════════════════════════")}\n`);
   console.log(chalk.gray("  Domain: ") + chalk.cyan(fullName));
+
+  return {
+    ok: true as const,
+    label: sublabel,
+    parent: parentLabel,
+    domain: fullName,
+    owner: ownerAddress,
+  };
 }
 
 async function executeGovernanceRegistration(

--- a/packages/cli/src/cli/commands/registerCommand.ts
+++ b/packages/cli/src/cli/commands/registerCommand.ts
@@ -5,6 +5,8 @@ import { type RegistrationCommandOptions } from "../../types/types";
 import { addAuthOptions, getAuthOptions } from "./authOptions";
 import { formatErrorMessage } from "../../utils/formatting";
 import { DEFAULT_COMMITMENT_BUFFER_SECONDS } from "../../utils/constants";
+import { getJsonFlag } from "./lookup";
+import { maybeQuiet } from "./bulletin";
 
 export type RegisterActionOptions = RegistrationCommandOptions & {
   __statusProvided?: boolean;
@@ -41,7 +43,9 @@ export function attachRegisterCommand(root: Command) {
       "--cb, --commitment-buffer <seconds>",
       `Extra seconds to wait after minCommitmentAge (default: ${DEFAULT_COMMITMENT_BUFFER_SECONDS}, env: DOTNS_COMMITMENT_BUFFER)`,
     )
+    .option("--json", "Output result as JSON (suppresses all other output)", false)
     .action(async (options: RegistrationCommandOptions, cmd: any) => {
+      const jsonOutput = getJsonFlag(cmd);
       try {
         const merged = { ...options, ...getAuthOptions(cmd) } as RegisterActionOptions;
 
@@ -55,10 +59,19 @@ export function attachRegisterCommand(root: Command) {
           throw new Error("Missing transfer destination: use --to <evm|ss58|label>");
         }
 
-        await executeRegistration(merged);
+        const result = await maybeQuiet(jsonOutput, () => executeRegistration(merged));
+
+        if (jsonOutput) {
+          process.stdout.write(JSON.stringify(result) + "\n");
+        }
         process.exit(0);
       } catch (error) {
-        console.error(`\n${chalk.red.bold("✗ Error:")} ${formatErrorMessage(error)}\n`);
+        const errorMessage = formatErrorMessage(error);
+        if (jsonOutput) {
+          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          process.exit(1);
+        }
+        console.error(`\n${chalk.red.bold("✗ Error:")} ${errorMessage}\n`);
         process.exit(1);
       }
     });
@@ -71,14 +84,25 @@ export function attachRegisterCommand(root: Command) {
     .requiredOption("-n, --name <label>", "Subname label to register")
     .requiredOption("-p, --parent <label>", "Parent domain label (without .dot)")
     .option("-o, --owner <address>", "Owner address (EVM or Substrate, or label)")
+    .option("--json", "Output result as JSON (suppresses all other output)", false)
     .action(async (options: any, cmd: any) => {
+      const jsonOutput = getJsonFlag(cmd);
       try {
         const merged = { ...options, ...getAuthOptions(cmd) } as RegisterActionOptions;
 
-        await executeSubnameRegistration(merged);
+        const result = await maybeQuiet(jsonOutput, () => executeSubnameRegistration(merged));
+
+        if (jsonOutput) {
+          process.stdout.write(JSON.stringify(result) + "\n");
+        }
         process.exit(0);
       } catch (error) {
-        console.error(`\n${chalk.red.bold("✗ Error:")} ${formatErrorMessage(error)}\n`);
+        const errorMessage = formatErrorMessage(error);
+        if (jsonOutput) {
+          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          process.exit(1);
+        }
+        console.error(`\n${chalk.red.bold("✗ Error:")} ${errorMessage}\n`);
         process.exit(1);
       }
     });

--- a/packages/cli/src/cli/commands/registerCommand.ts
+++ b/packages/cli/src/cli/commands/registerCommand.ts
@@ -3,9 +3,7 @@ import { executeRegistration, executeSubnameRegistration } from "./register";
 import { type RegistrationCommandOptions } from "../../types/types";
 import { addAuthOptions, getAuthOptions } from "./authOptions";
 import { DEFAULT_COMMITMENT_BUFFER_SECONDS } from "../../utils/constants";
-import { getJsonFlag } from "./lookup";
-import { maybeQuiet } from "./bulletin";
-import { emitJsonResult, handleCommandError } from "./jsonHelpers";
+import { getJsonFlag, maybeQuiet, emitJsonResult, handleCommandError } from "./jsonHelpers";
 
 export type RegisterActionOptions = RegistrationCommandOptions & {
   __statusProvided?: boolean;

--- a/packages/cli/src/cli/commands/registerCommand.ts
+++ b/packages/cli/src/cli/commands/registerCommand.ts
@@ -1,12 +1,11 @@
 import { Command } from "commander";
-import chalk from "chalk";
 import { executeRegistration, executeSubnameRegistration } from "./register";
 import { type RegistrationCommandOptions } from "../../types/types";
 import { addAuthOptions, getAuthOptions } from "./authOptions";
-import { formatErrorMessage } from "../../utils/formatting";
 import { DEFAULT_COMMITMENT_BUFFER_SECONDS } from "../../utils/constants";
 import { getJsonFlag } from "./lookup";
 import { maybeQuiet } from "./bulletin";
+import { emitJsonResult, handleCommandError } from "./jsonHelpers";
 
 export type RegisterActionOptions = RegistrationCommandOptions & {
   __statusProvided?: boolean;
@@ -61,18 +60,10 @@ export function attachRegisterCommand(root: Command) {
 
         const result = await maybeQuiet(jsonOutput, () => executeRegistration(merged));
 
-        if (jsonOutput) {
-          console.log(JSON.stringify(result));
-        }
+        emitJsonResult(jsonOutput, result);
         process.exit(0);
       } catch (error) {
-        const errorMessage = formatErrorMessage(error);
-        if (jsonOutput) {
-          console.error(JSON.stringify({ error: errorMessage }));
-          process.exit(1);
-        }
-        console.error(`\n${chalk.red.bold("✗ Error:")} ${errorMessage}\n`);
-        process.exit(1);
+        handleCommandError(jsonOutput, error);
       }
     });
 
@@ -92,18 +83,10 @@ export function attachRegisterCommand(root: Command) {
 
         const result = await maybeQuiet(jsonOutput, () => executeSubnameRegistration(merged));
 
-        if (jsonOutput) {
-          console.log(JSON.stringify(result));
-        }
+        emitJsonResult(jsonOutput, result);
         process.exit(0);
       } catch (error) {
-        const errorMessage = formatErrorMessage(error);
-        if (jsonOutput) {
-          console.error(JSON.stringify({ error: errorMessage }));
-          process.exit(1);
-        }
-        console.error(`\n${chalk.red.bold("✗ Error:")} ${errorMessage}\n`);
-        process.exit(1);
+        handleCommandError(jsonOutput, error);
       }
     });
 

--- a/packages/cli/src/cli/commands/registerCommand.ts
+++ b/packages/cli/src/cli/commands/registerCommand.ts
@@ -62,13 +62,13 @@ export function attachRegisterCommand(root: Command) {
         const result = await maybeQuiet(jsonOutput, () => executeRegistration(merged));
 
         if (jsonOutput) {
-          process.stdout.write(JSON.stringify(result) + "\n");
+          console.log(JSON.stringify(result));
         }
         process.exit(0);
       } catch (error) {
         const errorMessage = formatErrorMessage(error);
         if (jsonOutput) {
-          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          console.error(JSON.stringify({ error: errorMessage }));
           process.exit(1);
         }
         console.error(`\n${chalk.red.bold("✗ Error:")} ${errorMessage}\n`);
@@ -93,13 +93,13 @@ export function attachRegisterCommand(root: Command) {
         const result = await maybeQuiet(jsonOutput, () => executeSubnameRegistration(merged));
 
         if (jsonOutput) {
-          process.stdout.write(JSON.stringify(result) + "\n");
+          console.log(JSON.stringify(result));
         }
         process.exit(0);
       } catch (error) {
         const errorMessage = formatErrorMessage(error);
         if (jsonOutput) {
-          process.stderr.write(JSON.stringify({ error: errorMessage }) + "\n");
+          console.error(JSON.stringify({ error: errorMessage }));
           process.exit(1);
         }
         console.error(`\n${chalk.red.bold("✗ Error:")} ${errorMessage}\n`);

--- a/packages/cli/src/cli/commands/store.ts
+++ b/packages/cli/src/cli/commands/store.ts
@@ -3,8 +3,8 @@ import chalk from "chalk";
 import { isAddress, getAddress, type Address } from "viem";
 import { addAuthOptions, getAuthOptions } from "./authOptions";
 import { prepareAssetHubContext } from "../context";
-import { prepareReadOnlyContext, getJsonFlag } from "./lookup";
-import { maybeQuiet } from "./bulletin";
+import { prepareReadOnlyContext } from "./lookup";
+import { getJsonFlag, maybeQuiet } from "./jsonHelpers";
 import { formatErrorMessage } from "../../utils/formatting";
 import {
   getStoreInfo,

--- a/packages/cli/src/cli/commands/text.ts
+++ b/packages/cli/src/cli/commands/text.ts
@@ -1,10 +1,10 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import type { CommandOptions } from "../../types/types";
 import { viewDomainText, setDomainText } from "../../commands/textRecord";
 import { addAuthOptions } from "./authOptions";
 import { prepareContext } from "../context";
 import { prepareReadOnlyContext } from "./lookup";
+import { getMergedOptions } from "./jsonHelpers";
 import { formatErrorMessage } from "../../utils/formatting";
 import ora from "ora";
 
@@ -14,25 +14,6 @@ export interface TextViewOptions {
 
 export interface TextSetOptions {
   rpc?: string;
-}
-
-function getMergedOptions<T>(command: Command | undefined, fallback: T): CommandOptions & T {
-  const mergedOptions: any = { ...(fallback ?? {}) };
-
-  let currentCommand: Command | null | undefined = command?.parent;
-  while (currentCommand) {
-    if (typeof currentCommand.opts === "function") {
-      const parentOptions = currentCommand.opts();
-      for (const key in parentOptions) {
-        if (!(key in mergedOptions) && parentOptions[key] !== undefined) {
-          mergedOptions[key] = parentOptions[key];
-        }
-      }
-    }
-    currentCommand = currentCommand.parent;
-  }
-
-  return mergedOptions;
 }
 
 export function attachTextCommands(root: Command) {

--- a/packages/cli/src/commands/contentHash.ts
+++ b/packages/cli/src/commands/contentHash.ts
@@ -92,12 +92,12 @@ export async function viewDomainContentHash(
   console.log(chalk.gray("  contenthash: ") + chalk.white(contentHashBytes));
   console.log(chalk.gray("  cid:         ") + chalk.cyan(decodedCid));
 
-  const hasContent =
-    contentHashBytes !== "0x" && contentHashBytes !== "0x0" && contentHashBytes.length >= 6;
+  const hasContent = decodedCid !== "No CID set";
+  const cidResolved = hasContent && !decodedCid.startsWith("Unable to decode:") ? decodedCid : null;
   return {
     domain: `${label}.dot`,
     contenthash: hasContent ? contentHashBytes : null,
-    cid: hasContent && decodedCid !== `Unable to decode: ${contentHashBytes}` ? decodedCid : null,
+    cid: cidResolved,
   };
 }
 

--- a/packages/cli/src/commands/contentHash.ts
+++ b/packages/cli/src/commands/contentHash.ts
@@ -22,12 +22,26 @@ function encodeCidToContenthash(cidString: string): Hex {
   return `0x${encoded}` as Hex;
 }
 
+export type ContentViewResult = {
+  domain: string;
+  contenthash: string | null;
+  cid: string | null;
+};
+
+export type ContentSetResult = {
+  ok: true;
+  domain: string;
+  cid: string;
+  contenthash: string;
+  txHash: string;
+};
+
 export async function viewDomainContentHash(
   clientWrapper: ReviveClientWrapper,
   originSubstrateAddress: string,
   label: string,
   spinner: Ora,
-): Promise<void> {
+): Promise<ContentViewResult> {
   const namehashNode = namehash(`${label}.dot`);
   spinner.start("Querying registry");
 
@@ -60,7 +74,7 @@ export async function viewDomainContentHash(
 
   if (!recordExists || ownerAddress === zeroAddress) {
     console.log(chalk.yellow("  status: Domain not registered"));
-    return;
+    return { domain: `${label}.dot`, contenthash: null, cid: null };
   }
 
   const contentHashBytes = await performContractCall<Hex>(
@@ -77,6 +91,13 @@ export async function viewDomainContentHash(
   console.log(chalk.gray("  resolver:    ") + chalk.white(CONTRACTS.DOTNS_CONTENT_RESOLVER));
   console.log(chalk.gray("  contenthash: ") + chalk.white(contentHashBytes));
   console.log(chalk.gray("  cid:         ") + chalk.cyan(decodedCid));
+
+  const hasContent = contentHashBytes !== "0x" && contentHashBytes !== "0x0" && contentHashBytes.length >= 6;
+  return {
+    domain: `${label}.dot`,
+    contenthash: hasContent ? contentHashBytes : null,
+    cid: hasContent && decodedCid !== `Unable to decode: ${contentHashBytes}` ? decodedCid : null,
+  };
 }
 
 export async function setDomainContentHash(
@@ -86,7 +107,7 @@ export async function setDomainContentHash(
   label: string,
   contentId: string,
   spinner: Ora,
-): Promise<void> {
+): Promise<ContentSetResult> {
   const namehashNode = namehash(`${label}.dot`);
 
   console.log(chalk.gray("  domain: ") + chalk.cyan(`${label}.dot`));
@@ -165,4 +186,12 @@ export async function setDomainContentHash(
 
   console.log();
   console.log(chalk.gray("  new: ") + chalk.cyan(updatedCid));
+
+  return {
+    ok: true as const,
+    domain: `${label}.dot`,
+    cid: contentId,
+    contenthash: contentBytes,
+    txHash: transactionHash,
+  };
 }

--- a/packages/cli/src/commands/contentHash.ts
+++ b/packages/cli/src/commands/contentHash.ts
@@ -92,7 +92,8 @@ export async function viewDomainContentHash(
   console.log(chalk.gray("  contenthash: ") + chalk.white(contentHashBytes));
   console.log(chalk.gray("  cid:         ") + chalk.cyan(decodedCid));
 
-  const hasContent = contentHashBytes !== "0x" && contentHashBytes !== "0x0" && contentHashBytes.length >= 6;
+  const hasContent =
+    contentHashBytes !== "0x" && contentHashBytes !== "0x0" && contentHashBytes.length >= 6;
   return {
     domain: `${label}.dot`,
     contenthash: hasContent ? contentHashBytes : null,

--- a/packages/cli/tests/_helpers/cliHelpers.ts
+++ b/packages/cli/tests/_helpers/cliHelpers.ts
@@ -215,6 +215,13 @@ export async function createDefaultAccountKeystore(
   return { testMnemonic };
 }
 
+export async function expectJsonHelpOption(args: string[]): Promise<void> {
+  const result = await runDotnsCli([...args, "--help"]);
+  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
+  expect(result.combinedOutput).toContain("--json");
+  expect(result.combinedOutput).toContain("Output result as JSON");
+}
+
 export function generateGovernanceLabel(maxLen = 5): string {
   const alphabet = "abcdefghijklmnopqrstuvwxyz";
   const len = Math.max(1, Math.min(5, maxLen));

--- a/packages/cli/tests/integration/content/content.test.ts
+++ b/packages/cli/tests/integration/content/content.test.ts
@@ -223,3 +223,90 @@ test(
   },
   { timeout: TEST_TIMEOUT_MS },
 );
+
+// --json tests
+
+test(
+  "content view --json returns structured result for registered domain",
+  async () => {
+    const result = await runDotnsCli(["content", "view", REGISTERED_DOMAIN, "--json"]);
+
+    expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+    expect(result.combinedOutput).not.toContain("▶");
+    expect(result.combinedOutput).not.toContain("✓");
+
+    const parsed = JSON.parse(result.combinedOutput.trim());
+
+    expect(parsed.domain).toBe(`${REGISTERED_DOMAIN}.dot`);
+    expect(parsed).toHaveProperty("contenthash");
+    expect(parsed).toHaveProperty("cid");
+  },
+  { timeout: TEST_TIMEOUT_MS },
+);
+
+test(
+  "content view --json returns nulls for unregistered domain",
+  async () => {
+    const result = await runDotnsCli(["content", "view", UNREGISTERED_DOMAIN, "--json"]);
+
+    expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+    const parsed = JSON.parse(result.combinedOutput.trim());
+
+    expect(parsed.domain).toBe(`${UNREGISTERED_DOMAIN}.dot`);
+    expect(parsed.contenthash).toBeNull();
+    expect(parsed.cid).toBeNull();
+  },
+  { timeout: TEST_TIMEOUT_MS },
+);
+
+test(
+  "content set --json returns structured result",
+  async () => {
+    const result = await runDotnsCli([
+      "content",
+      "--key-uri",
+      "//Alice",
+      "set",
+      REGISTERED_DOMAIN,
+      TEST_CID,
+      "--json",
+    ]);
+
+    expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+    expect(result.combinedOutput).not.toContain("▶");
+    expect(result.combinedOutput).not.toContain("✓");
+
+    const parsed = JSON.parse(result.combinedOutput.trim());
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.domain).toBe(`${REGISTERED_DOMAIN}.dot`);
+    expect(parsed.cid).toBeString();
+    expect(parsed.contenthash).toBeString();
+    expect(parsed.txHash).toBeString();
+  },
+  { timeout: TEST_TIMEOUT_MS },
+);
+
+test(
+  "content set --json emits JSON error for unregistered domain",
+  async () => {
+    const result = await runDotnsCli([
+      "content",
+      "--key-uri",
+      "//Alice",
+      "set",
+      UNREGISTERED_DOMAIN,
+      TEST_CID,
+      "--json",
+    ]);
+
+    expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+    const parsed = JSON.parse(result.standardError.trim());
+    expect(parsed.error).toContain("is not registered");
+  },
+  { timeout: TEST_TIMEOUT_MS },
+);

--- a/packages/cli/tests/integration/pop/setPop.test.ts
+++ b/packages/cli/tests/integration/pop/setPop.test.ts
@@ -227,3 +227,43 @@ test(
   },
   { timeout: TEST_TIMEOUT_MS },
 );
+
+// --json tests
+
+test(
+  "pop info --json returns structured result",
+  async () => {
+    const result = await runDotnsCli(["pop", "--key-uri", "//Alice", "info", "--json"]);
+
+    expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+    expect(result.combinedOutput).not.toContain("📋");
+    expect(result.combinedOutput).not.toContain("✓");
+
+    const parsed = JSON.parse(result.combinedOutput.trim());
+
+    expect(parsed.substrate).toBeString();
+    expect(parsed.evm).toBeString();
+    expect(parsed.status).toBeString();
+    expect(parsed.statusCode).toBeNumber();
+  },
+  { timeout: TEST_TIMEOUT_MS },
+);
+
+test(
+  "pop set --json returns structured result",
+  async () => {
+    const result = await runDotnsCli(["pop", "--key-uri", "//Alice", "set", "lite", "--json"]);
+
+    expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+    expect(result.combinedOutput).not.toContain("✓ PoP Status Updated");
+
+    const parsed = JSON.parse(result.combinedOutput.trim());
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.status).toBeString();
+    expect(parsed.statusCode).toBeNumber();
+  },
+  { timeout: TEST_TIMEOUT_MS },
+);

--- a/packages/cli/tests/integration/register/register.test.ts
+++ b/packages/cli/tests/integration/register/register.test.ts
@@ -254,3 +254,33 @@ test(
   },
   { timeout: REGISTER_TEST_TIMEOUT_MS },
 );
+
+// --json tests
+
+test(
+  "register domain --json returns structured result",
+  async () => {
+    createPathsForTest("register_domain_json");
+    const keystorePath = await ensureDefaultKeystore();
+    const label = generateRandomLabel(ProofOfPersonhoodStatus.NoStatus);
+
+    const result = await runDotnsCli(
+      ["register", "domain", "--account", TEST_ACCOUNT, "--name", label, "--json"],
+      { DOTNS_KEYSTORE_PATH: keystorePath, DOTNS_KEYSTORE_PASSWORD: TEST_PASSWORD },
+    );
+
+    expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+    expect(result.combinedOutput).not.toContain("═══");
+    expect(result.combinedOutput).not.toContain("▶");
+    expect(result.combinedOutput).not.toContain("✓");
+
+    const parsed = JSON.parse(result.combinedOutput.trim());
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.label).toBe(label);
+    expect(parsed.domain).toBe(`${label}.dot`);
+    expect(parsed.owner).toBeString();
+  },
+  { timeout: REGISTER_TEST_TIMEOUT_MS },
+);

--- a/packages/cli/tests/unit/content/contentJson.test.ts
+++ b/packages/cli/tests/unit/content/contentJson.test.ts
@@ -1,26 +1,14 @@
 import { expect, test } from "bun:test";
 import {
-  HARNESS_HELP_SUCCESS_EXIT_CODE,
   HARNESS_SUCCESS_EXIT_CODE,
   runDotnsCli,
+  expectJsonHelpOption,
 } from "../../_helpers/cliHelpers";
 import { DEFAULT_MNEMONIC } from "../../../src/utils/constants";
 
-test("content view --help shows --json option", async () => {
-  const result = await runDotnsCli(["content", "view", "--help"]);
+test("content view --help shows --json option", () => expectJsonHelpOption(["content", "view"]));
 
-  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
-  expect(result.combinedOutput).toContain("--json");
-  expect(result.combinedOutput).toContain("Output result as JSON");
-});
-
-test("content set --help shows --json option", async () => {
-  const result = await runDotnsCli(["content", "set", "--help"]);
-
-  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
-  expect(result.combinedOutput).toContain("--json");
-  expect(result.combinedOutput).toContain("Output result as JSON");
-});
+test("content set --help shows --json option", () => expectJsonHelpOption(["content", "set"]));
 
 test("content set --json emits JSON error when both mnemonic and key-uri provided", async () => {
   const result = await runDotnsCli([

--- a/packages/cli/tests/unit/content/contentJson.test.ts
+++ b/packages/cli/tests/unit/content/contentJson.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+import {
+  HARNESS_HELP_SUCCESS_EXIT_CODE,
+  HARNESS_SUCCESS_EXIT_CODE,
+  runDotnsCli,
+} from "../../_helpers/cliHelpers";
+import { DEFAULT_MNEMONIC } from "../../../src/utils/constants";
+
+test("content view --help shows --json option", async () => {
+  const result = await runDotnsCli(["content", "view", "--help"]);
+
+  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
+  expect(result.combinedOutput).toContain("--json");
+  expect(result.combinedOutput).toContain("Output result as JSON");
+});
+
+test("content set --help shows --json option", async () => {
+  const result = await runDotnsCli(["content", "set", "--help"]);
+
+  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
+  expect(result.combinedOutput).toContain("--json");
+  expect(result.combinedOutput).toContain("Output result as JSON");
+});
+
+test("content set --json emits JSON error when both mnemonic and key-uri provided", async () => {
+  const result = await runDotnsCli([
+    "content",
+    "--mnemonic",
+    DEFAULT_MNEMONIC,
+    "--key-uri",
+    "//Alice",
+    "set",
+    "testdomain",
+    "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    "--json",
+  ]);
+
+  expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+  const errorOutput = result.standardError.trim();
+  const parsed = JSON.parse(errorOutput);
+  expect(parsed.error).toContain("Cannot specify both");
+});

--- a/packages/cli/tests/unit/pop/popJson.test.ts
+++ b/packages/cli/tests/unit/pop/popJson.test.ts
@@ -1,18 +1,6 @@
-import { expect, test } from "bun:test";
-import { HARNESS_HELP_SUCCESS_EXIT_CODE, runDotnsCli } from "../../_helpers/cliHelpers";
+import { test } from "bun:test";
+import { expectJsonHelpOption } from "../../_helpers/cliHelpers";
 
-test("pop set --help shows --json option", async () => {
-  const result = await runDotnsCli(["pop", "set", "--help"]);
+test("pop set --help shows --json option", () => expectJsonHelpOption(["pop", "set"]));
 
-  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
-  expect(result.combinedOutput).toContain("--json");
-  expect(result.combinedOutput).toContain("Output result as JSON");
-});
-
-test("pop info --help shows --json option", async () => {
-  const result = await runDotnsCli(["pop", "info", "--help"]);
-
-  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
-  expect(result.combinedOutput).toContain("--json");
-  expect(result.combinedOutput).toContain("Output result as JSON");
-});
+test("pop info --help shows --json option", () => expectJsonHelpOption(["pop", "info"]));

--- a/packages/cli/tests/unit/pop/popJson.test.ts
+++ b/packages/cli/tests/unit/pop/popJson.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import { HARNESS_HELP_SUCCESS_EXIT_CODE, runDotnsCli } from "../../_helpers/cliHelpers";
+
+test("pop set --help shows --json option", async () => {
+  const result = await runDotnsCli(["pop", "set", "--help"]);
+
+  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
+  expect(result.combinedOutput).toContain("--json");
+  expect(result.combinedOutput).toContain("Output result as JSON");
+});
+
+test("pop info --help shows --json option", async () => {
+  const result = await runDotnsCli(["pop", "info", "--help"]);
+
+  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
+  expect(result.combinedOutput).toContain("--json");
+  expect(result.combinedOutput).toContain("Output result as JSON");
+});

--- a/packages/cli/tests/unit/register/registerJson.test.ts
+++ b/packages/cli/tests/unit/register/registerJson.test.ts
@@ -1,25 +1,15 @@
 import { expect, test } from "bun:test";
 import {
-  HARNESS_HELP_SUCCESS_EXIT_CODE,
   HARNESS_SUCCESS_EXIT_CODE,
   runDotnsCli,
+  expectJsonHelpOption,
 } from "../../_helpers/cliHelpers";
 
-test("register domain --help shows --json option", async () => {
-  const result = await runDotnsCli(["register", "domain", "--help"]);
+test("register domain --help shows --json option", () =>
+  expectJsonHelpOption(["register", "domain"]));
 
-  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
-  expect(result.combinedOutput).toContain("--json");
-  expect(result.combinedOutput).toContain("Output result as JSON");
-});
-
-test("register subname --help shows --json option", async () => {
-  const result = await runDotnsCli(["register", "subname", "--help"]);
-
-  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
-  expect(result.combinedOutput).toContain("--json");
-  expect(result.combinedOutput).toContain("Output result as JSON");
-});
+test("register subname --help shows --json option", () =>
+  expectJsonHelpOption(["register", "subname"]));
 
 test("register domain --json emits JSON error when --transfer without --to", async () => {
   const result = await runDotnsCli([

--- a/packages/cli/tests/unit/register/registerJson.test.ts
+++ b/packages/cli/tests/unit/register/registerJson.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import {
+  HARNESS_HELP_SUCCESS_EXIT_CODE,
+  HARNESS_SUCCESS_EXIT_CODE,
+  runDotnsCli,
+} from "../../_helpers/cliHelpers";
+
+test("register domain --help shows --json option", async () => {
+  const result = await runDotnsCli(["register", "domain", "--help"]);
+
+  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
+  expect(result.combinedOutput).toContain("--json");
+  expect(result.combinedOutput).toContain("Output result as JSON");
+});
+
+test("register subname --help shows --json option", async () => {
+  const result = await runDotnsCli(["register", "subname", "--help"]);
+
+  expect(result.exitCode).toBe(HARNESS_HELP_SUCCESS_EXIT_CODE);
+  expect(result.combinedOutput).toContain("--json");
+  expect(result.combinedOutput).toContain("Output result as JSON");
+});
+
+test("register domain --json emits JSON error when --transfer without --to", async () => {
+  const result = await runDotnsCli([
+    "register",
+    "domain",
+    "--name",
+    "testlabel",
+    "--transfer",
+    "--key-uri",
+    "//Alice",
+    "--json",
+  ]);
+
+  expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+  const errorOutput = result.standardError.trim();
+  const parsed = JSON.parse(errorOutput);
+  expect(parsed.error).toContain("Missing transfer destination");
+});


### PR DESCRIPTION
## Summary

Adds `--json` flag to 6 commands that lacked it (`content view`, `content set`, `pop set`, `pop info`, `register domain`, `register subname`). The `bulletin` and `lookup` commands already had `--json`.

Replaces #74 (fork PR → upstream branch to fix CI permissions).

### Changes from #74

- Switched JSON output from `process.stdout.write` to `console.log` (and `process.stderr.write` to `console.error`) to align with the existing `--json` pattern in `lookup.ts`. The test harness only intercepts `console.log`/`console.error`, so the previous approach wouldn't have been captured in tests.
- Added code comment explaining why ora spinners are safe inside `maybeQuiet`: `withCapturedConsole` replaces `.write` on the `process.stderr` object, and ora caches the stream object reference (not the method), so spinner output is captured when the spinner lifecycle runs inside `maybeQuiet`.
- Added unit tests (8 tests): `--json` flag in help output, JSON error formatting for pre-chain validation errors.
- Added integration tests (7 tests): happy-path JSON output for all 6 commands plus error path for `content set`.

### JSON output shapes

```
dotns register domain -n <label> --json
→ { "ok": true, "label": "...", "domain": "....dot", "owner": "0x..." }

dotns register subname -n <sub> -p <parent> --json
→ { "ok": true, "label": "...", "parent": "...", "domain": "sub.parent.dot", "owner": "0x..." }

dotns content view <name> --json
→ { "domain": "....dot", "contenthash": "0x...", "cid": "bafy..." }

dotns content set <name> <cid> --json
→ { "ok": true, "domain": "....dot", "cid": "bafy...", "contenthash": "0x...", "txHash": "0x..." }

dotns pop set <status> --json
→ { "ok": true, "status": "full", "statusCode": 2 }

dotns pop info --json
→ { "substrate": "5D...", "evm": "0x...", "status": "proofofpersonhoodfull", "statusCode": 2 }

Errors (all commands):
→ stderr: { "error": "..." }
→ exit code 1
```

## Reviewer feedback addressed

1. **Console leak in contentHash.ts** — Verified that `withCapturedConsole` intercepts `process.stderr.write` (not just `console.log`), so ora spinner output is captured when `maybeQuiet` wraps the call scope. Added code comment explaining the mechanism.
2. **Automated tests** — Added 8 unit tests and 7 integration tests covering all `--json` commands.
3. **Push to upstream** — This PR comes from an in-repo branch, fixing the fork CI permissions issue.

## Test plan

- [x] Unit tests pass: `bun test tests/unit/` (142 tests, 0 failures)
- [ ] Integration tests pass against Paseo testnet
- [ ] CI passes (no longer fork-blocked)