### PR TITLE
chore(cli): QOF fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @filvecchiato @waytwotall @andrew-ifrita @corey-hathaway @sphamjoli
+* @waytwotall @andrew-ifrita @sphamjoli

--- a/packages/cli/src/cli/commands/bulletin.ts
+++ b/packages/cli/src/cli/commands/bulletin.ts
@@ -421,7 +421,7 @@ export function attachBulletinCommands(root: Command): void {
         );
 
         const signerContext = await withBulletinHumanOutput(reporterMode, () =>
-          prepareContext({ keyUri: signerKeyUri, useBulletin: true }),
+          prepareContext({ keyUri: signerKeyUri, useBulletin: true, bulletinRpc }),
         );
 
         if (!jsonOutput) {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -33,7 +33,24 @@ function toSafeAccountFilename(accountName: string): string {
   return `${safeFilename}.json`;
 }
 
+function resolveAuthSourceFromEnv(account: string): ResolvedAuthSource | undefined {
+  const envMnemonic = process.env[ENV.MNEMONIC];
+  if (envMnemonic && envMnemonic.length > 0) {
+    return { source: envMnemonic, isKeyUri: false, resolvedFrom: "env", account };
+  }
+
+  const envKeyUri = process.env[ENV.KEY_URI];
+  if (envKeyUri && envKeyUri.length > 0) {
+    return { source: envKeyUri, isKeyUri: true, resolvedFrom: "env", account };
+  }
+
+  return undefined;
+}
+
 export async function resolveAuthSourceReadOnly(): Promise<ResolvedAuthSource> {
+  const fromEnv = resolveAuthSourceFromEnv("readonly");
+  if (fromEnv) return fromEnv;
+
   return {
     source: DEFAULT_MNEMONIC,
     isKeyUri: false,
@@ -52,15 +69,8 @@ export async function resolveAuthSource(opts: AuthSource): Promise<ResolvedAuthS
     return { source: opts.keyUri, isKeyUri: true, resolvedFrom: "cli", account: accountName };
   }
 
-  const envMnemonic = process.env[ENV.MNEMONIC];
-  const envKeyUri = process.env[ENV.KEY_URI];
-
-  if (envMnemonic && envMnemonic.length > 0) {
-    return { source: envMnemonic, isKeyUri: false, resolvedFrom: "env", account: accountName };
-  }
-  if (envKeyUri && envKeyUri.length > 0) {
-    return { source: envKeyUri, isKeyUri: true, resolvedFrom: "env", account: accountName };
-  }
+  const fromEnv = resolveAuthSourceFromEnv(accountName);
+  if (fromEnv) return fromEnv;
 
   const keystoreDirectoryPath = resolveKeystorePath(opts.keystorePath);
 

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -714,6 +714,8 @@ export async function setUserProofOfPersonhoodStatus(
   const checkSpinner = ora(`Checking current PoP status for ${displayName}`).start();
 
   try {
+    await clientWrapper.ensureAccountMapped(substrateAddress, signer);
+
     const currentStatus = await getUserProofOfPersonhoodStatus(
       clientWrapper,
       substrateAddress,

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -23,6 +23,8 @@ export const DOT_NODE: Hex = "0x3fce7d1364a893e213bc4212792b517ffc88f5b13b86c8ef
 
 export const DECIMALS = 12n;
 
+export const DECIMALS_DOT = 10n;
+
 export const NATIVE_TO_ETH_RATIO = 1_000_000n;
 
 export const DEFAULT_MNEMONIC =

--- a/packages/cli/src/utils/formatting.ts
+++ b/packages/cli/src/utils/formatting.ts
@@ -3,15 +3,15 @@ import type { Ora } from "ora";
 import { formatEther } from "viem";
 import { printHumanDetail, printHumanFailure, printHumanSuccess } from "../cli/reporter";
 import type { TransactionStatus } from "../types/types";
-import { DECIMALS, NATIVE_TO_ETH_RATIO } from "./constants";
+import { DECIMALS_DOT, NATIVE_TO_ETH_RATIO } from "./constants";
 
 export function formatNativeBalance(valueInNativeUnits: bigint): string {
-  const divisor = 10n ** DECIMALS;
+  const divisor = 10n ** DECIMALS_DOT;
   const wholePart = valueInNativeUnits / divisor;
   const fractionalPart = valueInNativeUnits % divisor;
 
   let fractionalString = fractionalPart.toString();
-  const missingZeroCount = DECIMALS - BigInt(fractionalString.length);
+  const missingZeroCount = DECIMALS_DOT - BigInt(fractionalString.length);
   if (missingZeroCount > 0n) {
     fractionalString = "0".repeat(Number(missingZeroCount)) + fractionalString;
   }
@@ -24,9 +24,11 @@ export function parseNativeBalance(decimalValue: string): bigint {
   const wholePart = BigInt(parts[0] || "0");
   const fractionalPart = parts[1] || "0";
 
-  const paddedFraction = fractionalPart.padEnd(Number(DECIMALS), "0").slice(0, Number(DECIMALS));
+  const paddedFraction = fractionalPart
+    .padEnd(Number(DECIMALS_DOT), "0")
+    .slice(0, Number(DECIMALS_DOT));
 
-  return wholePart * 10n ** DECIMALS + BigInt(paddedFraction);
+  return wholePart * 10n ** DECIMALS_DOT + BigInt(paddedFraction);
 }
 
 export function convertNativeToWei(nativeValue: bigint): bigint {

--- a/packages/cli/tests/unit/auth/resolveAuthSourceReadOnly.test.ts
+++ b/packages/cli/tests/unit/auth/resolveAuthSourceReadOnly.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { resolveAuthSourceReadOnly } from "../../../src/commands/auth";
+import { DEFAULT_MNEMONIC } from "../../../src/utils/constants";
+import { ENV } from "../../../src/cli/env";
+import { ALICE_KEY_URI } from "../../_helpers/cliHelpers";
+
+const CUSTOM_MNEMONIC =
+  "absorb oppose idea expire husband layer subject flip pause ahead daring stem";
+
+const previousEnv = {
+  mnemonic: process.env[ENV.MNEMONIC],
+  keyUri: process.env[ENV.KEY_URI],
+};
+
+function clearAuthEnv(): void {
+  delete process.env[ENV.MNEMONIC];
+  delete process.env[ENV.KEY_URI];
+}
+
+function restoreAuthEnv(): void {
+  if (previousEnv.mnemonic === undefined) delete process.env[ENV.MNEMONIC];
+  else process.env[ENV.MNEMONIC] = previousEnv.mnemonic;
+
+  if (previousEnv.keyUri === undefined) delete process.env[ENV.KEY_URI];
+  else process.env[ENV.KEY_URI] = previousEnv.keyUri;
+}
+
+afterEach(() => {
+  restoreAuthEnv();
+});
+
+type EnvCase = {
+  label: string;
+  env: { mnemonic?: string; keyUri?: string };
+  expected: { source: string; isKeyUri: boolean; resolvedFrom: "env" | "default" };
+};
+
+const envCases: EnvCase[] = [
+  {
+    label: "no env falls back to DEFAULT_MNEMONIC",
+    env: {},
+    expected: { source: DEFAULT_MNEMONIC, isKeyUri: false, resolvedFrom: "default" },
+  },
+  {
+    label: "DOTNS_MNEMONIC is used when set",
+    env: { mnemonic: CUSTOM_MNEMONIC },
+    expected: { source: CUSTOM_MNEMONIC, isKeyUri: false, resolvedFrom: "env" },
+  },
+  {
+    label: "DOTNS_KEY_URI is used when mnemonic is absent",
+    env: { keyUri: ALICE_KEY_URI },
+    expected: { source: ALICE_KEY_URI, isKeyUri: true, resolvedFrom: "env" },
+  },
+  {
+    label: "DOTNS_MNEMONIC takes precedence over DOTNS_KEY_URI",
+    env: { mnemonic: CUSTOM_MNEMONIC, keyUri: ALICE_KEY_URI },
+    expected: { source: CUSTOM_MNEMONIC, isKeyUri: false, resolvedFrom: "env" },
+  },
+  {
+    label: "empty DOTNS_MNEMONIC falls through to default",
+    env: { mnemonic: "" },
+    expected: { source: DEFAULT_MNEMONIC, isKeyUri: false, resolvedFrom: "default" },
+  },
+];
+
+describe("resolveAuthSourceReadOnly honours environment variables (regression for #114)", () => {
+  test.each(envCases)("$label", async ({ env, expected }) => {
+    clearAuthEnv();
+    if (env.mnemonic !== undefined) process.env[ENV.MNEMONIC] = env.mnemonic;
+    if (env.keyUri !== undefined) process.env[ENV.KEY_URI] = env.keyUri;
+
+    const resolved = await resolveAuthSourceReadOnly();
+
+    expect(resolved.source).toBe(expected.source);
+    expect(resolved.isKeyUri).toBe(expected.isKeyUri);
+    expect(resolved.resolvedFrom).toBe(expected.resolvedFrom);
+  });
+});

--- a/packages/cli/tests/unit/pop/setPopMapsAccount.test.ts
+++ b/packages/cli/tests/unit/pop/setPopMapsAccount.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { encodeFunctionResult } from "viem";
+import type { PolkadotSigner } from "polkadot-api";
+import {
+  getUserProofOfPersonhoodStatus,
+  setUserProofOfPersonhoodStatus,
+} from "../../../src/commands/register";
+import { POP_RULES_ABI } from "../../../src/utils/constants";
+import { ProofOfPersonhoodStatus } from "../../../src/types/types";
+import type { ReviveClientWrapper } from "../../../src/client/polkadotClient";
+
+type CallEvent = "ensureAccountMapped" | "performDryRunCall" | "submitTransaction";
+
+function createTrackingClient(currentStatus: ProofOfPersonhoodStatus) {
+  const callOrder: CallEvent[] = [];
+
+  const encodedStatus = encodeFunctionResult({
+    abi: POP_RULES_ABI,
+    functionName: "userPopStatus",
+    result: BigInt(currentStatus) as any,
+  });
+
+  const client = {
+    async ensureAccountMapped() {
+      callOrder.push("ensureAccountMapped");
+    },
+    async performDryRunCall() {
+      callOrder.push("performDryRunCall");
+      return { result: { value: { data: encodedStatus, flags: 0n } } };
+    },
+    async submitTransaction() {
+      callOrder.push("submitTransaction");
+      return "0xdeadbeef" as const;
+    },
+  } as unknown as ReviveClientWrapper;
+
+  return { client, callOrder };
+}
+
+const substrateAddress = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const evmAddress = "0x000000000000000000000000000000000000dead" as const;
+const placeholderSigner = {} as PolkadotSigner;
+
+describe("setUserProofOfPersonhoodStatus maps account before dry-run (regression for #89)", () => {
+  test("ensureAccountMapped runs before the PoP dry-run read", async () => {
+    const { client, callOrder } = createTrackingClient(
+      ProofOfPersonhoodStatus.ProofOfPersonhoodFull,
+    );
+
+    await setUserProofOfPersonhoodStatus(
+      client,
+      substrateAddress,
+      placeholderSigner,
+      evmAddress,
+      "",
+      ProofOfPersonhoodStatus.ProofOfPersonhoodFull,
+    );
+
+    const mapIndex = callOrder.indexOf("ensureAccountMapped");
+    const dryRunIndex = callOrder.indexOf("performDryRunCall");
+
+    expect(mapIndex).toBeGreaterThanOrEqual(0);
+    expect(dryRunIndex).toBeGreaterThanOrEqual(0);
+    expect(mapIndex).toBeLessThan(dryRunIndex);
+  });
+
+  test("skips submitTransaction when current status equals desired", async () => {
+    const { client, callOrder } = createTrackingClient(
+      ProofOfPersonhoodStatus.ProofOfPersonhoodLite,
+    );
+
+    await setUserProofOfPersonhoodStatus(
+      client,
+      substrateAddress,
+      placeholderSigner,
+      evmAddress,
+      "",
+      ProofOfPersonhoodStatus.ProofOfPersonhoodLite,
+    );
+
+    expect(callOrder).not.toContain("submitTransaction");
+  });
+
+  test("getUserProofOfPersonhoodStatus alone does not map the account", async () => {
+    const { client, callOrder } = createTrackingClient(ProofOfPersonhoodStatus.NoStatus);
+
+    await getUserProofOfPersonhoodStatus(client, substrateAddress, evmAddress);
+
+    expect(callOrder).toContain("performDryRunCall");
+    expect(callOrder).not.toContain("ensureAccountMapped");
+  });
+});

--- a/packages/cli/tests/unit/utils/formatting.test.ts
+++ b/packages/cli/tests/unit/utils/formatting.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { formatNativeBalance, parseNativeBalance } from "../../../src/utils/formatting";
+import { DECIMALS, DECIMALS_DOT } from "../../../src/utils/constants";
+
+describe("native balance formatting uses DOT/PAS 10 decimals", () => {
+  test("DECIMALS_DOT is 10 (native DOT/PAS) and DECIMALS is 12 (Revive native)", () => {
+    expect(DECIMALS_DOT).toBe(10n);
+    expect(DECIMALS).toBe(12n);
+  });
+
+  test("formatNativeBalance renders 5000 PAS from 5000 * 10^10 units", () => {
+    const fiveThousandPasInSmallestUnits = 5000n * 10n ** 10n;
+    expect(formatNativeBalance(fiveThousandPasInSmallestUnits)).toBe("5000.0000000000");
+  });
+
+  test("formatNativeBalance renders fractional 0.1 PAS as 10^9 units", () => {
+    expect(formatNativeBalance(10n ** 9n)).toBe("0.1000000000");
+  });
+
+  test("formatNativeBalance renders zero balance", () => {
+    expect(formatNativeBalance(0n)).toBe("0.0000000000");
+  });
+
+  test("parseNativeBalance inverts formatNativeBalance", () => {
+    const original = 5000n * 10n ** 10n + 1234567890n;
+    expect(parseNativeBalance(formatNativeBalance(original))).toBe(original);
+  });
+
+  test("parseNativeBalance('0.1') is 10^9", () => {
+    expect(parseNativeBalance("0.1")).toBe(10n ** 9n);
+  });
+});


### PR DESCRIPTION
## Description

Four independent CLI bug fixes.

1. **`pop set` reverts for unmapped accounts** ([#89](https://github.com/paritytech/dotns/issues/89)) — `setUserProofOfPersonhoodStatus` dry-reads PoP status before the account is mapped. Revive requires the origin to be mapped to an H160 even for a read, so fresh mnemonic accounts revert. Fix: call `ensureAccountMapped` at the top of the function.

2. **Balance displays 100× too low** ([#90](https://github.com/paritytech/dotns/issues/90)) — `formatNativeBalance` / `parseNativeBalance` used `DECIMALS = 12n` (Revive native-to-wei scale) to render on-chain balances, which are 10-decimal. Fix: introduce `DECIMALS_DOT = 10n` for the native balance path; `DECIMALS = 12n` is unchanged.

3. **`dotns pop info` ignores `DOTNS_MNEMONIC`** ([#114](https://github.com/paritytech/dotns/issues/114)) — `resolveAuthSourceReadOnly()` returned `DEFAULT_MNEMONIC` unconditionally, so read-only commands showed the default account regardless of env. Fix: honour `DOTNS_MNEMONIC` / `DOTNS_KEY_URI` before falling back to default.

4. **`bulletin authorize` ignores `--bulletin-rpc`** ([#133](https://github.com/paritytech/dotns/issues/133)) — the authorize action built the signer context without forwarding `bulletinRpc`, so it fell back to the Asset Hub default RPC. Fix: thread `bulletinRpc` into the options passed to `prepareContext`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Chore

## Package

- [x] `@parity/dotns-cli`
- [ ] Root/monorepo
- [ ] Documentation

## Related Issues

- [paritytech/dotns#89](https://github.com/paritytech/dotns/issues/89)
- [paritytech/dotns#90](https://github.com/paritytech/dotns/issues/90)
- [paritytech/dotns#114](https://github.com/paritytech/dotns/issues/114)
- [paritytech/dotns#133](https://github.com/paritytech/dotns/issues/133)

## Fixes

Fixes paritytech/dotns#89
Fixes paritytech/dotns#90
Fixes paritytech/dotns#114
Fixes paritytech/dotns#133

## Checklist

### Code

- [x] Follows project style
- [x] `bun run lint` passes
- [x] `bun run format` passes
- [x] `bun run typecheck` passes

### Documentation

- [x] README updated if needed
- [x] Types updated if needed

### Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

**Breaking changes:**

None.

## Testing

Added unit tests for each fix:

- `tests/unit/utils/formatting.test.ts` — pins `DECIMALS_DOT = 10n`, `DECIMALS = 12n`, and round-trips `formatNativeBalance` / `parseNativeBalance`.
- `tests/unit/auth/resolveAuthSourceReadOnly.test.ts` — parameterised env-precedence matrix.
- `tests/unit/pop/setPopMapsAccount.test.ts` — asserts `ensureAccountMapped` runs before `performDryRunCall` in `setUserProofOfPersonhoodStatus`.

### How to test manually

1. **#89** — `dotns pop set full -m "<fresh mnemonic with PAS>"`. Previously: `Contract reverted (flags=1)`. Now: status set, transaction lands.
2. **#90** — run any command that prints the balance line (e.g. `dotns pop set full -m "…"`). Previously: `50.000000000000 PAS` for a 5000 PAS account. Now: `5000.0000000000 PAS`.
3. **#114** — `export DOTNS_MNEMONIC="…"; dotns pop info`. Previously: shows the default account. Now: shows the account derived from the env mnemonic.
4. **#133** — run the reusable deploy workflow with a custom `bulletin-rpc`. Previously: the authorize step connected to the default Asset Hub RPC. Now: it uses the Bulletin RPC that was passed.