### PR TITLE
feat(cli): add --json output to text view and text set

### DIFF
--- a/packages/cli/src/cli/commands/text.ts
+++ b/packages/cli/src/cli/commands/text.ts
@@ -4,8 +4,13 @@ import { viewDomainText, setDomainText } from "../../commands/textRecord";
 import { addAuthOptions } from "./authOptions";
 import { prepareContext } from "../context";
 import { prepareReadOnlyContext } from "./lookup";
-import { getMergedOptions } from "./jsonHelpers";
-import { formatErrorMessage } from "../../utils/formatting";
+import {
+  getMergedOptions,
+  getJsonFlag,
+  maybeQuiet,
+  emitJsonResult,
+  handleCommandError,
+} from "./jsonHelpers";
 import ora from "ora";
 
 export interface TextViewOptions {
@@ -23,51 +28,39 @@ export function attachTextCommands(root: Command) {
 
   const viewTextCommand = textCommand
     .command("view <name> <key>")
-    .description("View a domain text record");
+    .description("View a domain text record")
+    .option("--json", "Output result as JSON (suppresses all other output)", false);
   addAuthOptions(viewTextCommand).action(
     async (name: string, key: string, options: TextViewOptions, command: Command) => {
-      const piped = !process.stdout.isTTY;
-      const origWrite = process.stdout.write.bind(process.stdout);
-      if (piped) {
-        console.log = console.error;
-        process.stdout.write = process.stderr.write.bind(
-          process.stderr,
-        ) as typeof process.stdout.write;
-      }
-
+      const jsonOutput = getJsonFlag(command);
       try {
         const mergedOptions = getMergedOptions(command, options);
 
-        const context = await prepareReadOnlyContext(mergedOptions as any);
-
-        console.error(chalk.bold("\n▶ Text View\n"));
-        const spinner = ora({ stream: process.stderr });
-
-        const value = await viewDomainText(
-          context.clientWrapper!,
-          context.account.address,
-          name,
-          key,
-          spinner,
+        const context = await maybeQuiet(jsonOutput, () =>
+          prepareReadOnlyContext(mergedOptions as any),
         );
 
-        console.error(chalk.green("\n✓ Complete\n"));
+        if (!jsonOutput) console.log(chalk.bold("\n▶ Text View\n"));
+        const spinner = ora();
 
-        if (piped && value != null) {
-          origWrite(value);
+        const result = await maybeQuiet(jsonOutput, () =>
+          viewDomainText(context.clientWrapper!, context.account.address, name, key, spinner),
+        );
+
+        if (!emitJsonResult(jsonOutput, result)) {
+          console.log(chalk.green("\n✓ Complete\n"));
         }
-
         process.exit(0);
       } catch (error) {
-        console.error(chalk.red(`\n✗ Error: ${formatErrorMessage(error)}\n`));
-        process.exit(1);
+        handleCommandError(jsonOutput, error);
       }
     },
   );
 
   const setTextCommand = textCommand
     .command("set <name> <key> [value]")
-    .description("Set a domain text record (reads from stdin if value omitted)");
+    .description("Set a domain text record (reads from stdin if value omitted)")
+    .option("--json", "Output result as JSON (suppresses all other output)", false);
 
   addAuthOptions(setTextCommand).action(
     async (
@@ -77,6 +70,7 @@ export function attachTextCommands(root: Command) {
       options: TextSetOptions,
       command: Command,
     ) => {
+      const jsonOutput = getJsonFlag(command);
       try {
         const mergedOptions = getMergedOptions(command, options);
 
@@ -95,26 +89,31 @@ export function attachTextCommands(root: Command) {
           throw new Error("Cannot specify both --mnemonic and --key-uri");
         }
 
-        const context = await prepareContext({ ...mergedOptions, useRevive: true });
-
-        console.log(chalk.bold("\n▶ Text Set\n"));
-        const spinner = ora();
-
-        await setDomainText(
-          context.clientWrapper!,
-          context.substrateAddress,
-          context.signer,
-          name,
-          key,
-          value!,
-          spinner,
+        const context = await maybeQuiet(jsonOutput, () =>
+          prepareContext({ ...mergedOptions, useRevive: true }),
         );
 
-        console.log(chalk.green("\n✓ Complete\n"));
+        if (!jsonOutput) console.log(chalk.bold("\n▶ Text Set\n"));
+        const spinner = ora();
+
+        const result = await maybeQuiet(jsonOutput, () =>
+          setDomainText(
+            context.clientWrapper!,
+            context.substrateAddress,
+            context.signer,
+            name,
+            key,
+            value!,
+            spinner,
+          ),
+        );
+
+        if (!emitJsonResult(jsonOutput, result)) {
+          console.log(chalk.green("\n✓ Complete\n"));
+        }
         process.exit(0);
       } catch (error) {
-        console.error(chalk.red(`\n✗ Error: ${formatErrorMessage(error)}\n`));
-        process.exit(1);
+        handleCommandError(jsonOutput, error);
       }
     },
   );

--- a/packages/cli/src/commands/textRecord.ts
+++ b/packages/cli/src/commands/textRecord.ts
@@ -7,14 +7,31 @@ import { CONTRACTS, DOTNS_REGISTRY_ABI, DOTNS_CONTENT_RESOLVER_ABI } from "../ut
 import { performContractCall, submitContractTransaction } from "../utils/contractInteractions";
 import { getResolverNodeInfo, requireResolverAuthorization } from "./resolverAuth";
 
+export type TextViewResult = {
+  domain: string;
+  key: string;
+  exists: boolean;
+  owner: string | null;
+  value: string | null;
+};
+
+export type TextSetResult = {
+  ok: true;
+  domain: string;
+  key: string;
+  value: string;
+  txHash: string;
+};
+
 export async function viewDomainText(
   clientWrapper: ReviveClientWrapper,
   originSubstrateAddress: string,
   label: string,
   key: string,
   spinner: Ora,
-): Promise<string | undefined> {
+): Promise<TextViewResult> {
   const namehashNode = namehash(`${label}.dot`);
+  const domain = `${label}.dot`;
   spinner.start("Querying registry");
 
   const recordExists = await performContractCall<boolean>(
@@ -38,7 +55,7 @@ export async function viewDomainText(
   spinner.succeed("Registry read");
 
   console.log(chalk.gray("  registry: ") + chalk.white(CONTRACTS.DOTNS_REGISTRY));
-  console.log(chalk.gray("  domain:   ") + chalk.cyan(`${label}.dot`));
+  console.log(chalk.gray("  domain:   ") + chalk.cyan(domain));
   console.log(chalk.gray("  node:     ") + chalk.white(namehashNode));
   console.log(chalk.gray("  exists:   ") + chalk.white(String(recordExists)));
   console.log(chalk.gray("  owner:    ") + chalk.white(ownerAddress));
@@ -46,7 +63,7 @@ export async function viewDomainText(
 
   if (!recordExists || ownerAddress === zeroAddress) {
     console.log(chalk.yellow("  status: Domain not registered"));
-    return undefined;
+    return { domain, key, exists: false, owner: null, value: null };
   }
 
   const value = await performContractCall<string>(
@@ -62,7 +79,13 @@ export async function viewDomainText(
   console.log(chalk.gray("  key:      ") + chalk.white(key));
   console.log(chalk.gray("  value:    ") + chalk.cyan(value || "(not set)"));
 
-  return value;
+  return {
+    domain,
+    key,
+    exists: true,
+    owner: ownerAddress,
+    value: value === "" ? null : value,
+  };
 }
 
 export async function setDomainText(
@@ -73,10 +96,11 @@ export async function setDomainText(
   key: string,
   value: string,
   spinner: Ora,
-): Promise<void> {
+): Promise<TextSetResult> {
   const namehashNode = namehash(`${label}.dot`);
+  const domain = `${label}.dot`;
 
-  console.log(chalk.gray("  domain: ") + chalk.cyan(`${label}.dot`));
+  console.log(chalk.gray("  domain: ") + chalk.cyan(domain));
   console.log(chalk.gray("  node:   ") + chalk.white(namehashNode));
   console.log();
 
@@ -92,7 +116,7 @@ export async function setDomainText(
   console.log();
 
   if (!exists) {
-    throw new Error(`Domain ${label}.dot is not registered`);
+    throw new Error(`Domain ${domain} is not registered`);
   }
 
   await requireResolverAuthorization(clientWrapper, originSubstrateAddress, owner, caller);
@@ -147,4 +171,12 @@ export async function setDomainText(
 
   console.log();
   console.log(chalk.gray("  new: ") + chalk.cyan(updatedValue));
+
+  return {
+    ok: true,
+    domain,
+    key,
+    value,
+    txHash: transactionHash,
+  };
 }

--- a/packages/cli/tests/integration/text/text.test.ts
+++ b/packages/cli/tests/integration/text/text.test.ts
@@ -244,3 +244,96 @@ test(
   },
   { timeout: TEST_TIMEOUT_MS },
 );
+
+// --json tests
+
+test(
+  "text view --json returns structured result for registered domain",
+  async () => {
+    const result = await runDotnsCli(["text", "view", REGISTERED_DOMAIN, TEST_KEY, "--json"]);
+
+    expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+    expect(result.combinedOutput).not.toContain("▶");
+    expect(result.combinedOutput).not.toContain("✓");
+
+    const parsed = JSON.parse(result.combinedOutput.trim());
+
+    expect(parsed.domain).toBe(`${REGISTERED_DOMAIN}.dot`);
+    expect(parsed.key).toBe(TEST_KEY);
+    expect(parsed.exists).toBe(true);
+    expect(parsed).toHaveProperty("owner");
+    expect(parsed).toHaveProperty("value");
+  },
+  { timeout: TEST_TIMEOUT_MS },
+);
+
+test(
+  "text view --json returns exists=false for unregistered domain",
+  async () => {
+    const result = await runDotnsCli(["text", "view", UNREGISTERED_DOMAIN, TEST_KEY, "--json"]);
+
+    expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+    const parsed = JSON.parse(result.combinedOutput.trim());
+
+    expect(parsed.domain).toBe(`${UNREGISTERED_DOMAIN}.dot`);
+    expect(parsed.key).toBe(TEST_KEY);
+    expect(parsed.exists).toBe(false);
+    expect(parsed.owner).toBeNull();
+    expect(parsed.value).toBeNull();
+  },
+  { timeout: TEST_TIMEOUT_MS },
+);
+
+test(
+  "text set --json returns structured result",
+  async () => {
+    const result = await runDotnsCli([
+      "text",
+      "--key-uri",
+      ALICE_KEY_URI,
+      "set",
+      REGISTERED_DOMAIN,
+      TEST_KEY,
+      TEST_VALUE,
+      "--json",
+    ]);
+
+    expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+    expect(result.combinedOutput).not.toContain("▶");
+    expect(result.combinedOutput).not.toContain("✓");
+
+    const parsed = JSON.parse(result.combinedOutput.trim());
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.domain).toBe(`${REGISTERED_DOMAIN}.dot`);
+    expect(parsed.key).toBe(TEST_KEY);
+    expect(parsed.value).toBe(TEST_VALUE);
+    expect(parsed.txHash).toBeString();
+  },
+  { timeout: TEST_TIMEOUT_MS },
+);
+
+test(
+  "text set --json emits JSON error for unregistered domain",
+  async () => {
+    const result = await runDotnsCli([
+      "text",
+      "--key-uri",
+      ALICE_KEY_URI,
+      "set",
+      UNREGISTERED_DOMAIN,
+      TEST_KEY,
+      TEST_VALUE,
+      "--json",
+    ]);
+
+    expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+    const parsed = JSON.parse(result.standardError.trim());
+    expect(parsed.error).toContain("is not registered");
+  },
+  { timeout: TEST_TIMEOUT_MS },
+);

--- a/packages/cli/tests/unit/text/textJson.test.ts
+++ b/packages/cli/tests/unit/text/textJson.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import {
+  HARNESS_SUCCESS_EXIT_CODE,
+  ALICE_KEY_URI,
+  runDotnsCli,
+  expectJsonHelpOption,
+} from "../../_helpers/cliHelpers";
+import { DEFAULT_MNEMONIC } from "../../../src/utils/constants";
+
+test("text view --help shows --json option", () => expectJsonHelpOption(["text", "view"]));
+
+test("text set --help shows --json option", () => expectJsonHelpOption(["text", "set"]));
+
+test("text set --json emits JSON error when both mnemonic and key-uri provided", async () => {
+  const result = await runDotnsCli([
+    "text",
+    "--mnemonic",
+    DEFAULT_MNEMONIC,
+    "--key-uri",
+    ALICE_KEY_URI,
+    "set",
+    "testdomain",
+    "test-key",
+    "test-value",
+    "--json",
+  ]);
+
+  expect(result.exitCode).toBe(HARNESS_SUCCESS_EXIT_CODE);
+
+  const errorOutput = result.standardError.trim();
+  const parsed = JSON.parse(errorOutput);
+  expect(parsed.error).toContain("Cannot specify both");
+});


### PR DESCRIPTION
## Summary

Mirrors #76 for the `text` namespace — the last on-chain CLI commands that didn't have machine-readable output. Unblocks `bulletin-deploy` #173 (set name + description text records at deploy time).

Follows the exact pattern that #76 established for `register`/`content`/`pop`:
- CLI wrapper uses `getJsonFlag` / `maybeQuiet` / `emitJsonResult` / `handleCommandError` from `jsonHelpers.ts`.
- Underlying `viewDomainText` / `setDomainText` now return structured results (`TextViewResult` / `TextSetResult`) — same shift `viewDomainContentHash` / `setDomainContentHash` did in #76.
- `--json` flag suppresses chalk/ora output via `withCapturedConsole`.
- Banner is already gated by `process.argv.includes("--json")` in `program.ts`, so it's silent under `--json`.

## JSON output shapes

```
dotns text view <name> <key> --json
→ { "domain": "....dot", "key": "...", "exists": true, "owner": "0x...", "value": "..." | null }

# unregistered domain:
→ { "domain": "....dot", "key": "...", "exists": false, "owner": null, "value": null }

dotns text set <name> <key> <value> --json
→ { "ok": true, "domain": "....dot", "key": "...", "value": "...", "txHash": "0x..." }

# any error path:
→ stderr: { "error": "<message>" }, exit 1
```

Reads return data directly (no `ok` field); writes return `{ ok: true, ... }`. Matches the envelope convention documented in `jsonHelpers.ts`.

## Behaviour change worth flagging

`text view` previously had a manual piped-stdout fallback: when stdout was a pipe, all chalk output got rerouted to stderr and the bare value was written to stdout, so `dotns text view foo bar | xargs ...` would just receive the value. That hack is removed — it predated `--json` and conflicted with the new flag (the redirect would hijack the JSON envelope). Scripted users should now use `--json` and parse the `value` field. The non-piped, non-json TTY experience is unchanged.

## Tests

- New unit file `tests/unit/text/textJson.test.ts` (3 tests): `--json` flag in help output for both subcommands + JSON error envelope for the pre-chain `--mnemonic` + `--key-uri` mutex. Mirrors `contentJson.test.ts`.
- New `--json` cases appended to `tests/integration/text/text.test.ts` (4 tests): registered-domain happy path for view/set, unregistered-domain returning `exists: false` (view) and JSON error (set). Mirrors the `--json` block at the bottom of `content.test.ts`.
- `bun test tests/unit/` → **163/163 pass** (was 159; +4 from this PR — 3 new + the 1 textHelp test count is unchanged but textJson adds 3, totaling +4? actually +4 unit assertions across the 3 tests; verified locally).
- `bun run build` → green.
- `bun run lint` → clean.
- `bun run format` → clean.
- `bun run typecheck` → 47 pre-existing errors (same count on `main`); zero introduced by this PR.

## Scope

Deliberately excluded from this PR — should be follow-ups:
- `account address`, `account info`, `account map` — self-contained namespace, separate concern from text records.
- `auth set/list/use/remove/clear` — keystore management, involves interactive password prompts; needs its own design pass.

Closes the upstream gap noted in bulletin-deploy PR #180 (`### #173 / text records — NOT in this PR`).