### PR TITLE
chore(cli): refresh docs and bulletin allowance field reads

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+echo "Running formatters and linters before commit..."
+bun run precommit
+
+if ! git diff --quiet; then
+  echo ""
+  echo "Formatters or linters changed files. Review and stage the updates, then commit again."
+  git diff --name-only
+  exit 1
+fi

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -59,19 +59,37 @@ export DOTNS_KEYSTORE_PASSWORD=test-password
 # Then simply use --account
 dotns register domain --account karim --name coolname42
 dotns content set dotns bafybei... --account karim
-dotns pop set lite --account karim
+dotns pop status --account karim
 ```
 
 ## Environment Variables
 
-| Variable                  | Description                |
-| ------------------------- | -------------------------- |
-| `DOTNS_KEYSTORE_PATH`     | Path to keystore directory |
-| `DOTNS_KEYSTORE_PASSWORD` | Keystore password          |
-| `DOTNS_RPC`               | Asset Hub RPC endpoint     |
-| `DOTNS_MNEMONIC`          | BIP39 mnemonic phrase      |
-| `DOTNS_KEY_URI`           | Substrate key URI          |
-| `DOTNS_MIN_BALANCE_PAS`   | Minimum balance in PAS     |
+| Variable                  | Description                                        |
+| ------------------------- | -------------------------------------------------- |
+| `DOTNS_ENV`               | DotNS environment (`paseo-v2`; default `paseo-v2`) |
+| `DOTNS_KEYSTORE_PATH`     | Path to keystore directory                         |
+| `DOTNS_KEYSTORE_PASSWORD` | Keystore password                                  |
+| `DOTNS_RPC`               | Asset Hub RPC endpoint                             |
+| `DOTNS_MNEMONIC`          | BIP39 mnemonic phrase                              |
+| `DOTNS_KEY_URI`           | Substrate key URI                                  |
+| `DOTNS_MIN_BALANCE_PAS`   | Minimum balance in PAS                             |
+
+Select an environment with either an environment variable or a per-command option:
+
+```bash
+# Default: Paseo V2
+dotns account is-whitelisted 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+
+# Explicitly use Paseo V2 for this shell
+export DOTNS_ENV=paseo-v2
+dotns account is-whitelisted 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+
+# Or override for a single command
+dotns --env paseo-v2 account is-whitelisted 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+dotns account whitelist 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY --env paseo-v2 --key-uri //Alice
+```
+
+`--rpc` still overrides the endpoint URL, but it does not change the selected DotNS contract addresses. Use `--env`/`DOTNS_ENV` to select the DotNS deployment.
 
 ## Commands
 
@@ -83,11 +101,11 @@ All registration commands require authentication.
 # Register a base domain
 dotns --password test-password register domain --account default --name coolname42
 
-# With PoP Lite status
-dotns --password test-password register domain --account default --name alice99 --status lite
+# Register a name that requires PoP Lite
+dotns --password test-password register domain --account default --name alice99
 
-# With PoP Full status
-dotns --password test-password register domain --account default --name premium --status full
+# Register a name that requires PoP Full
+dotns --password test-password register domain --account default --name premium
 
 # Governance registration (≤5 chars, reserved names)
 dotns --password test-password register domain --account default --name short --governance
@@ -182,16 +200,17 @@ echo "https://alice.dev" | dotns --password test-password text set alice url --a
 
 ### Proof of Personhood
 
+The CLI reads PoP status directly from the personhood precompile at
+`0x000000000000000000000000000000000a010000` using the `bytes32("dotns")`
+context. Returned tiers are `none`, `lite`, or `full`; DotNS does not set this
+status.
+
 ```bash
-# Set PoP status with keystore
-dotns pop --password test-password --account default set lite
-dotns pop set full --password test-password --account default
-
-# Set PoP status with mnemonic
-dotns pop --mnemonic "bottom drive obey lake curtain smoke basket hold race lonely fit walk" set lite
-
-# Set PoP status with key-uri
-dotns pop --key-uri //Alice set lite
+# Check PoP status from the personhood precompile
+dotns pop --password test-password --account default status
+dotns pop status --password test-password --account default
+dotns pop --mnemonic "bottom drive obey lake curtain smoke basket hold race lonely fit walk" status
+dotns pop --key-uri //Alice status
 
 # View account info
 dotns pop --password test-password --account default info

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parity/dotns-cli",
   "module": "index.ts",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "private": true,
   "packageManager": "bun@1.2.6",

--- a/packages/cli/src/bulletin/ipfs.ts
+++ b/packages/cli/src/bulletin/ipfs.ts
@@ -1,18 +1,24 @@
 import type { VerificationResult, BlockVerificationResult } from "../types/types";
+import { PASEO_IPFS_GATEWAY_URL } from "../utils/constants";
 import { formatErrorMessage } from "../utils/formatting";
 async function loadHeliaClient() {
   const { getSharedHeliaClient } = await import("./heliaClient");
   return getSharedHeliaClient();
 }
 
-const DEFAULT_VERIFICATION_GATEWAY = "https://paseo-ipfs.polkadot.io";
+const DEFAULT_VERIFICATION_GATEWAY = PASEO_IPFS_GATEWAY_URL;
 const VERIFICATION_TIMEOUT_MILLISECONDS = 30000;
+
+function createIpfsGatewayUrl(gatewayBaseUrl: string, cid: string): string {
+  const gateway = gatewayBaseUrl.replace(/\/+$/, "");
+  return gateway.endsWith("/ipfs") ? `${gateway}/${cid}` : `${gateway}/ipfs/${cid}`;
+}
 
 export async function verifyCidResolution(
   contentCid: string,
   gatewayBaseUrl: string = DEFAULT_VERIFICATION_GATEWAY,
 ): Promise<VerificationResult> {
-  const verificationUrl = `${gatewayBaseUrl}/ipfs/${contentCid}`;
+  const verificationUrl = createIpfsGatewayUrl(gatewayBaseUrl, contentCid);
 
   try {
     const response = await fetch(verificationUrl, {
@@ -66,7 +72,7 @@ export async function verifyMultipleCids(
 export async function verifyCidWithMultipleGateways(
   contentCid: string,
   gatewayUrls: string[] = [
-    "https://paseo-ipfs.polkadot.io",
+    PASEO_IPFS_GATEWAY_URL,
     "https://dweb.link",
     "https://cloudflare-ipfs.com",
     "https://w3s.link",

--- a/packages/cli/src/commands/bulletin.ts
+++ b/packages/cli/src/commands/bulletin.ts
@@ -572,8 +572,8 @@ export async function checkAuthorization(
 
       return {
         authorized: true,
-        transactions_allowance: authorizationState.extent.transactions_allowance,
-        bytes_allowance: authorizationState.extent.bytes_allowance,
+        transactions_allowance: authorizationState.extent.transactions,
+        bytes_allowance: authorizationState.extent.bytes,
         expiration,
         currentBlock,
         expired,

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -27,7 +27,7 @@ bun install
 Generate Polkadot API descriptors:
 
 ```bash
-bunx papi add paseo -w wss://asset-hub-paseo-rpc.n.dwellir.com
+bunx papi add paseo -w wss://paseo-asset-hub-next-rpc.polkadot.io
 ```
 
 This generates the `.papi/` directory required by `polkadot-api`.
@@ -62,7 +62,7 @@ bun run preview
 The project currently targets Paseo. A typical endpoint is:
 
 ```text
-wss://asset-hub-paseo-rpc.n.dwellir.com
+wss://paseo-asset-hub-next-rpc.polkadot.io
 ```
 
 RPCs can be adjusted in code or environment configuration depending on deployment needs.

--- a/packages/ui/src/components/RegisterModal.vue
+++ b/packages/ui/src/components/RegisterModal.vue
@@ -127,7 +127,7 @@
                       {{ userPopStatus.message }}
                     </p>
                     <p v-if="!requirementMet" class="text-xs mt-2 text-amber-400 font-medium">
-                      Please update your PoP status to
+                      Your personhood verification must be
                       {{ PopStatusLabels[userPopStatus.requirement] }} to register this name.
                     </p>
                   </div>

--- a/packages/ui/src/components/preview/ErrorDisplay.vue
+++ b/packages/ui/src/components/preview/ErrorDisplay.vue
@@ -95,7 +95,7 @@ function handleRetry() {
           </button>
           <a
             v-if="cid"
-            :href="`https://paseo-ipfs.polkadot.io/ipfs/${cid}/`"
+            :href="`https://paseo-bulletin-next-ipfs.polkadot.io/ipfs/${cid}/`"
             target="_blank"
             rel="noopener noreferrer"
             class="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 text-dot-text-secondary hover:text-dot-text-primary rounded-lg border border-dot-border hover:border-dot-border-strong transition-colors text-sm"

--- a/packages/ui/src/lib/ipfs.ts
+++ b/packages/ui/src/lib/ipfs.ts
@@ -1,6 +1,6 @@
 import { getSharedHeliaClient, type HeliaContentFetchResult } from "@/lib/heliaClient";
 
-const BULLETIN_VERIFICATION_GATEWAY = "https://paseo-ipfs.polkadot.io";
+const BULLETIN_VERIFICATION_GATEWAY = "https://paseo-bulletin-next-ipfs.polkadot.io/ipfs";
 const GATEWAY_FETCH_TIMEOUT_MS = 15_000;
 const IPFS_VERIFICATION_TIMEOUT_MS = 15_000;
 const P2P_FETCH_TIMEOUT_MS = 10_000;
@@ -44,7 +44,8 @@ function normalizeGatewayUrl(gatewayBaseUrl: string): string {
 
 function getGatewayCandidateUrls(gatewayBaseUrl: string, cid: string): string[] {
   const gateway = normalizeGatewayUrl(gatewayBaseUrl);
-  return [`${gateway}/ipfs/${cid}`, `${gateway}/ipfs/${cid}/`];
+  const cidUrl = gateway.endsWith("/ipfs") ? `${gateway}/${cid}` : `${gateway}/ipfs/${cid}`;
+  return [cidUrl, `${cidUrl}/`];
 }
 
 function formatErrorMessage(error: unknown): string {

--- a/packages/ui/src/views/ProfileView.vue
+++ b/packages/ui/src/views/ProfileView.vue
@@ -467,7 +467,7 @@
                       </Button>
                       <Button size="sm" variant="secondary" as-child>
                         <a
-                          :href="`https://paseo-ipfs.polkadot.io/ipfs/${cid}`"
+                          :href="`https://paseo-bulletin-next-ipfs.polkadot.io/ipfs/${cid}`"
                           target="_blank"
                           rel="noopener noreferrer"
                         >

--- a/packages/ui/src/views/docs/tools/CliPage.vue
+++ b/packages/ui/src/views/docs/tools/CliPage.vue
@@ -341,10 +341,6 @@ const commandReference: CmdGroup[] = [
           "Register a new base domain. Runs the full commit-reveal flow: commit, wait, then reveal.",
         options: [
           { flag: "-n, --name <label>", description: "Domain label to register (without .dot)" },
-          {
-            flag: "-s, --status <level>",
-            description: "ProofOfPersonhood status: none, lite, or full",
-          },
           { flag: "-r, --reverse", description: "Also set as the reverse record" },
           { flag: "-g, --governance", description: "Use the governance registration path" },
           {
@@ -441,14 +437,10 @@ const commandReference: CmdGroup[] = [
   },
   {
     name: "pop",
-    description: "Manage ProofOfPersonhood status. Set your PoP tier or check your current level.",
+    description: "Read ProofOfPersonhood status from the personhood precompile.",
     subcommands: [
       {
-        usage: "pop set <status>",
-        description: "Set your ProofOfPersonhood status. Accepted values: none, lite, full.",
-      },
-      {
-        usage: "pop info",
+        usage: "pop status",
         description:
           "Display your current PoP status, including Substrate address and EVM address.",
       },
@@ -734,11 +726,8 @@ dotns account map
 # Check if an address is mapped
 dotns account is-mapped 5DtFfW...
 
-# Set PoP status
-dotns pop set lite
-
 # Check PoP status
-dotns pop info
+dotns pop status
 
 # Store: write a key-value pair
 dotns store set my-key "my-value"


### PR DESCRIPTION
## Summary
- Reads renamed `transactions` / `bytes` fields from `AuthorizationExtent` (the `_allowance` aliases no longer exist on the new chain types). This clears the lingering type errors on `main`.
- Updates the CLI README to reflect the env-aware command surface.
- Tidies the UI doc pages, register modal, error display, profile view, and IPFS helper.

## Test plan
- [ ] `bun run --cwd packages/cli typecheck`
- [ ] `bun run --cwd packages/cli test tests/integration/bulletin`
- [ ] Skim the rendered CLI page in the UI

## Order
Last in the stack. Base is `spha/cli-auto-claim-user-store` (#134).