### PR TITLE
fix: remove spha as core IC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @waytwotall @andrew-ifrita @sphamjoli
+* @waytwotall @andrew-ifrita

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @waytwotall @andrew-ifrita
+* @waytwotall


### PR DESCRIPTION
## Description
This PR removes spha as code owner 
## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [X] Chore

## Package

- [ ] `@parity/dotns-cli`
- [ ] Root/monorepo
- [ ] Documentation

## Related Issues

## Fixes 

## Checklist

### Code

- [X] Follows project style
- [X] `bun run lint` passes
- [X] `bun run format` passes
- [X] `bun run typecheck` passes

### Documentation

- [ ] README updated if needed
- [ ] Types updated if needed

### Breaking Changes

- [X] No breaking changes
- [ ] Breaking changes documented below

**Breaking changes:**

## Testing

How to test:

1. 
2. 

## Notes