### PR TITLE
chore(cli): checlist for opensource

### DIFF
--- a/.github/workflows/benchmark-on-demand.yml
+++ b/.github/workflows/benchmark-on-demand.yml
@@ -106,6 +106,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Setup CLI
         uses: ./.github/actions/setup-cli
@@ -153,6 +154,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/benchmark-ui-pr.yml
+++ b/.github/workflows/benchmark-ui-pr.yml
@@ -27,6 +27,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/daily-deploy-sized-benchmarks.yml
+++ b/.github/workflows/daily-deploy-sized-benchmarks.yml
@@ -360,6 +360,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Setup CLI
         uses: ./.github/actions/setup-cli

--- a/.github/workflows/deploy-sized-benchmark-entry.yml
+++ b/.github/workflows/deploy-sized-benchmark-entry.yml
@@ -66,6 +66,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Generate sized fixture
         run: |

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/format-ui.yml
+++ b/.github/workflows/format-ui.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
       - run: bun install --frozen-lockfile
 
       - name: Run format

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
       - run: bun install --frozen-lockfile
 
       - name: Run format

--- a/.github/workflows/lint-ui.yml
+++ b/.github/workflows/lint-ui.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
       - run: bun install --frozen-lockfile
 
       - name: Run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
       - run: bun install --frozen-lockfile
 
       - name: Run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Install dependencies
         shell: bash
@@ -287,6 +288,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,76 @@
+name: Secret Scan
+
+# Scans for committed secrets with Gitleaks on every pull request to main and
+# every push to main. The ruleset and allowlist live in .gitleaks.toml.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITLEAKS_VERSION: 8.30.1
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so a push to main scans the whole repository, not just
+          # the tip commit. Pull requests scan the merged working tree.
+          fetch-depth: 0
+
+      - name: Install Gitleaks
+        run: |
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            -o gitleaks.tar.gz
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo install gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan working tree for secrets
+        id: scan
+        run: |
+          set +e
+          gitleaks dir . \
+            --config .gitleaks.toml \
+            --redact \
+            --no-banner \
+            --report-format json \
+            --report-path gitleaks-report.json \
+            --log-level warn
+          SCAN_EXIT=$?
+          set -e
+
+          if [ "$SCAN_EXIT" -eq 0 ]; then
+            echo "No secrets detected."
+            exit 0
+          fi
+
+          COUNT=$(jq 'length' gitleaks-report.json 2>/dev/null || echo "?")
+          echo "::error::$COUNT potential secret(s) detected. See the gitleaks-report artifact."
+          jq -r '.[] | "- \(.File):\(.StartLine) [\(.RuleID)]"' \
+            gitleaks-report.json 2>/dev/null | head -50
+          echo ""
+          echo "If a finding is a false positive (generated or vendored content), add an" \
+            "allowlist entry to .gitleaks.toml. For a historical finding already removed" \
+            "from the tree, pin its fingerprint in .gitleaksignore."
+          exit 1
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: gitleaks-report
+          path: gitleaks-report.json
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/typecheck-ui.yml
+++ b/.github/workflows/typecheck-ui.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.6"
+          no-cache: true
 
       - name: Install dependencies
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,16 @@ benchmark-report.html
 .benchmark-temp
 arb-generated
 .abis-version
+
+# AI-assistant per-developer state. Session, cache, worktrees, and local
+# settings are personal scratch and never belong in the repo; intentional team
+# config (CLAUDE.md, .claude/commands, .claude/skills, .claude/agents) is not
+# ignored.
+.claude/sessions/
+.claude/cache/
+.claude/worktrees/
+.claude/settings.local.json
+.cursor/
+.aider*
+.codeium/
+.gemini/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,27 @@
+# Gitleaks configuration for dotns-sdk.
+#
+# Extends the upstream default ruleset and adds a project allowlist so the
+# scanner ignores generated and vendored content we do not author:
+#   1. Installed dependencies (node_modules).
+#   2. Build output (dist, out), including bundled and minified artefacts.
+#   3. Lockfiles, whose integrity hashes look like secrets but are not.
+#   4. Generated polkadot-api descriptors under packages/*/.papi.
+#
+# Anything outside those cases is a genuine finding and fails the scan.
+
+title = "dotns-sdk gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Generated, vendored, and lockfile content"
+
+paths = [
+  '''(^|/)node_modules/''',
+  '''(^|/)dist/''',
+  '''(^|/)out/''',
+  '''(^|/)bun\.lock$''',
+  '''(^|/)package-lock\.json$''',
+  '''(^|/)\.papi/''',
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to dotns-sdk
+
+These guidelines apply to the dotns-sdk repository. Contributions are welcome via issues, pull
+requests, reviews, and testing feedback. Project scope and structure live in [README.md](./README.md);
+this file is the contributor mechanics.
+
+## Types of contributing
+
+1. Opening an issue
+   - Check whether an issue already exists before creating a new one.
+   - If a related issue exists, add details there rather than duplicating.
+   - Use issues for bug reports, feature requests, and process suggestions.
+
+2. Resolving an issue
+   - Fix with code, tests, documentation, or by demonstrating expected behaviour.
+   - Reference the issue number in the pull request and commit messages where relevant.
+
+3. Reviewing open pull requests
+   - Review for correctness, type safety, test coverage, naming, and ergonomics.
+   - Flag potential edge cases, especially around name parsing, hashing, and transaction encoding.
+
+## Opening an issue
+
+When opening an issue, include:
+
+- A short, specific title.
+- Expected vs actual behaviour.
+- A minimal reproduction where possible (a test or a short script).
+- Environment details if relevant (Bun version, package, network, contracts release tag).
+
+If you are proposing an API or behaviour change, describe:
+
+- The problem being solved.
+- Compatibility and migration considerations.
+- Any security or UX implications.
+
+## Opening a pull request
+
+- Open pull requests against the `main` branch.
+- Link the issue being addressed (or describe the motivation if there is no issue).
+- Keep pull requests focused. If a change has multiple concerns, split it into smaller PRs.
+
+Before opening a pull request:
+
+- Install dependencies: `bun install`
+- Format: `bun run format`
+- Lint: `bun run lint`
+- Type-check: `bun run typecheck`
+- Run the tests: `bun test`
+- Add or update tests for new behaviour, especially anything that changes how a name is interpreted
+  or how a transaction is encoded.
+- Keep changes small enough to review, or explain the design trade-offs clearly.
+
+## Standards
+
+1. Formatting and linting
+   - All code should pass Biome formatting and linting and `tsc` type-checking.
+
+2. Public APIs
+   - Keep exported functions and types documented and stable.
+   - Treat a change to name interpretation or transaction encoding as a breaking change for clients:
+     document it, test it, and assume downstream consumers will break if it is ambiguous.
+
+3. Generated inputs
+   - ABIs are generated inputs synced from the DotNS contracts releases. Do not edit them by hand;
+     update them through the sync script.
+
+## Reporting security issues
+
+Do not open public issues for security vulnerabilities. Follow the disclosure process in
+[SECURITY.md](./SECURITY.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Parity Technologies (UK) Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ DotNS will be accessed from multiple surfaces: scripts, command-line tools, web 
 
 This monorepo exists to concentrate shared logic in one place, with explicit boundaries, shared primitives, and a small set of versioned artefacts that multiple runtimes can consume.
 
+## Status
+
+This is reference and proof-of-concept tooling for the DotNS protocol, intended for reference and experimentation rather than as a production-ready artefact. Unless a specific release states otherwise, it has not received a full security audit; see [SECURITY.md](./SECURITY.md) for the security status and disclosure process. The defaults target Paseo and its Bulletin chain; point the configuration at your own network before relying on it elsewhere.
+
 ## Scope
 
 **Client-side** here means off-chain code that reads and writes DotNS contracts. The repository is cross-platform:
@@ -152,4 +156,8 @@ Prefer:
 * Changes accompanied by invariant-style tests, especially when touching name parsing, hashing, or transaction encoding
 
 If a change alters how a name is interpreted or how a transaction is encoded, treat it like a consensus change for clients: document it, test it, and assume downstream consumers will break if it is ambiguous.
+
+## License
+
+Licensed under the MIT License. See [LICENSE](./LICENSE). Security policy and disclosure: see [SECURITY.md](./SECURITY.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,83 @@
+# Security policy
+
+## Security status
+
+This repository contains the DotNS client SDK and tooling: reference and proof-of-concept libraries,
+a command-line tool, and examples for interacting with the DotNS protocol. It is intended for
+reference and experimentation, not as a production-ready artefact.
+
+Unless a specific release states otherwise, this repository has **not** received a full security
+audit. Use in production or production-like contexts should only follow an independent security
+review of the relevant code, configuration, and the environment it runs in.
+
+Even where no Parity-operated production deployment exists today, this code may be consumed by third
+parties in live applications, or reused in future production contexts once published.
+
+## Static analysis
+
+The codebase is checked on every pull request by automated tooling, currently linting and
+formatting (Biome), type-checking (TypeScript), and dependency and supply-chain scanning (Socket).
+All findings raised by these tools have been reviewed and are deemed false positives or accepted
+non-issues for this codebase. They are retained for transparency rather than as a list of
+outstanding defects, so a tool reporting a finding is not in itself grounds for a vulnerability
+report. If you believe a specific finding has genuine, demonstrable impact, raise it through the
+disclosure process below with the evidence required under "What to report".
+
+## Supported versions
+
+Security fixes are provided only for versions, packages, or branches actively maintained by Parity.
+Experimental, archived, deprecated, or explicitly-unsupported packages, examples, or branches may
+not be triaged unless the issue affects maintained packages, Parity-operated infrastructure, user
+funds, private keys, signing flows, or transaction integrity.
+
+## Bug bounty scope
+
+This repository is **not** in scope for Parity's paid bug bounty programme unless explicitly listed
+in the official bounty scope at the time of submission. Reports may still be reviewed through
+responsible disclosure, but bounty eligibility applies only where the affected asset or vulnerability
+class is explicitly in scope.
+
+## What to report
+
+Report an issue only if it demonstrates realistic impact against one or more of:
+
+- Parity-operated production infrastructure or deployed services;
+- maintained packages downstream users are expected to consume;
+- user funds or assets;
+- private keys, seed phrases, signer flows, or key-management boundaries;
+- transaction construction, integrity, or signing intent;
+- remote code execution or credential compromise in a realistic deployment.
+
+## Out of scope (unless shown to cause realistic high-impact harm)
+
+Local-development-only issues; demo/example/testnet-only issues; missing rate limiting in local
+examples; dependency reports without a working exploit path or that don't affect shipped packages;
+hypothetical attack paths; "this code is unaudited"; documented known limitations; unsafe use
+contrary to documented warnings; issues requiring access to internal Parity systems not in scope.
+
+## Reporting a qualifying issue
+
+Do **not** open a public issue for a qualifying vulnerability. Email **security@parity.io** with:
+
+- the affected repository, package, commit, branch, or release;
+- clear reproduction steps and realistic impact;
+- whether it affects production infrastructure, maintained packages, user funds, keys, signing, or
+  only local/demo/testnet usage;
+- any proof of concept, logs, or generated code involved;
+- assumptions required for exploitation.
+
+## Researcher expectations
+
+Don't access, modify, or delete data that isn't yours; don't disrupt services; don't extract keys or
+secrets beyond what's needed to demonstrate impact safely; don't test against production systems not
+in scope; no social engineering or physical attacks; don't disclose publicly until Parity has had a
+reasonable opportunity to remediate.
+
+## Safe-use guidance
+
+Before relying on this SDK in any production or production-like context, review at minimum: how the
+consuming application generates, stores, and destroys keys, seeds, and signers; whether signing
+prompts display transaction intent before approval; whether transactions are built against the
+intended chain, account, and network; whether examples rely on test or unstable endpoints; whether
+inputs such as names and addresses are validated before use; and whether dependencies are pinned and
+reviewed before being shipped.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "module": "index.ts",
   "type": "module",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "hooks:install": "git config core.hooksPath .githooks",
     "prepare": "git config core.hooksPath .githooks || true",

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Parity Technologies (UK) Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,7 @@
   "version": "0.7.0",
   "type": "module",
   "private": true,
+  "license": "MIT",
   "packageManager": "bun@1.2.6",
   "files": [
     "dist"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,7 @@
   "name": "dotns-ui",
   "version": "0.6.2",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "packageManager": "bun@1.2.6",
   "scripts": {


### PR DESCRIPTION
## Description
Prepares dotns-sdk for open sourcing. Declares the licence in three places (root `LICENSE`, the licence field on the root and workspace packages, and a README note) and adds a LICENSE inside the publishable CLI package so it ships in the npm tarball. Adds SECURITY.md and CONTRIBUTING.md, a README status section flagging the code as reference-only and not audited, and secret scanning (a gitleaks config plus a workflow that runs on every pull request and push to main). Adds AI-assistant ignore rules to .gitignore. Also adds no-cache to every setup-bun step, so the action stops restoring a cache that lacks the bun binary.

## Type
- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [x] Documentation
- [x] Chore

## Package
- [x] `@parity/dotns-cli`
- [x] Root/monorepo
- [x] Documentation

## Related Issues
None.

## Fixes
setup-bun jobs failing with "Unable to locate executable file: ~/.bun/bin/bun" when a cache without the binary is restored.

## Checklist
### Code
- [x] Follows project style
- [x] `bun run lint` passes
- [x] `bun run format` passes
- [x] `bun run typecheck` passes

### Documentation
- [x] README updated if needed
- [x] Types updated if needed

### Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

**Breaking changes:**

None.

## Testing
How to test:

1. Run `gitleaks dir . --config .gitleaks.toml` and a full-history scan (`gitleaks git . --log-opts="--all" --config .gitleaks.toml`). Both report no leaks.
2. Run `bun run format`. It passes for the CLI, the UI, and the workflow YAML.
3. Confirm `LICENSE`, `SECURITY.md`, and `CONTRIBUTING.md` exist, and that the README has Status and License sections.

## Notes
The change set is documentation, CI, and configuration only; no TypeScript source changed, so lint and typecheck are unaffected, and format was run and passes. Dependency licences were audited: no copyleft reaches the published MIT CLI package; the GPL dependencies are confined to the private, unpublished UI app. ABI sync depends on the DotNS contracts repository being public with a release, which is handled separately.