### PR TITLE
chore: enable 0 amount labels with info warning

### DIFF
--- a/packages/ui/src/components/profile/EscrowTab.vue
+++ b/packages/ui/src/components/profile/EscrowTab.vue
@@ -94,11 +94,26 @@
                   {{ formatWeiAsEther(p.amount) }} PAS
                 </td>
                 <td class="px-4 py-2.5">
-                  <span :class="positionStatusClass(p)">{{ positionStatusLabel(p) }}</span>
+                  <span class="inline-flex items-center gap-1">
+                    <span :class="positionStatusClass(p)">{{ positionStatusLabel(p) }}</span>
+                    <span
+                      v-if="isNonRefundable(p)"
+                      :title="NON_REFUNDABLE_HINT"
+                      class="cursor-help text-dot-text-tertiary"
+                    >
+                      <Icon name="Info" size="sm" />
+                    </span>
+                  </span>
                 </td>
                 <td class="px-4 py-2.5 text-right">
+                  <span
+                    v-if="isNonRefundable(p) && !p.released"
+                    class="text-xs text-dot-text-tertiary"
+                  >
+                    No refund
+                  </span>
                   <Button
-                    v-if="!p.released"
+                    v-else-if="!p.released"
                     size="sm"
                     variant="secondary"
                     :disabled="busyId === p.domain"
@@ -250,10 +265,16 @@ import {
   isWithdrawable as isWithdrawableAt,
   positionStatusLabel as positionStatusLabelAt,
   isRefundClaimable as isRefundClaimableAt,
+  isRefundableDeposit,
   cooldownRemainingSeconds,
   formatCooldown,
   totalEscrowAmount,
 } from "@/lib/escrowStatus";
+
+// Shown on names whose escrow position holds no deposit: paid for by another
+// account, or registered under a free personhood tier. There is no bond to reclaim.
+const NON_REFUNDABLE_HINT =
+  "This name holds no refundable deposit. It was either paid for by another account or registered under a free personhood tier, so there is no bond for you to reclaim.";
 
 const wallet = useWalletStore();
 const escrow = useEscrowStore();
@@ -298,10 +319,14 @@ function cooldownText(position: EscrowPosition): string {
   return formatCooldown(cooldownRemainingSeconds(position, now.value));
 }
 
+function isNonRefundable(position: EscrowPosition): boolean {
+  return !isRefundableDeposit(position);
+}
+
 function positionStatusClass(position: EscrowPosition): string {
   const label = positionStatusLabel(position);
   if (label === "Withdrawable") return "text-success font-medium";
-  if (label === "Cooldown") return "text-dot-text-tertiary";
+  if (label === "Cooldown" || label === "Not refundable") return "text-dot-text-tertiary";
   return "text-dot-text-secondary";
 }
 

--- a/packages/ui/src/lib/escrowStatus.test.ts
+++ b/packages/ui/src/lib/escrowStatus.test.ts
@@ -40,8 +40,8 @@ describe("isAccountPosition", () => {
     expect(isAccountPosition({ recipient: other, amount: 5n }, recipient)).toBe(false);
   });
 
-  it("rejects a zero-amount position", () => {
-    expect(isAccountPosition({ recipient, amount: 0n }, recipient)).toBe(false);
+  it("keeps a zero-amount position so non-refundable names can be surfaced", () => {
+    expect(isAccountPosition({ recipient, amount: 0n }, recipient)).toBe(true);
   });
 });
 
@@ -118,6 +118,10 @@ describe("positionStatusLabel", () => {
 
   it("labels a held deposit", () => {
     expect(positionStatusLabel(base, NOW)).toBe("Held");
+  });
+
+  it("labels a zero-amount unreleased position as not refundable", () => {
+    expect(positionStatusLabel({ ...base, amount: 0n }, NOW)).toBe("Not refundable");
   });
 
   it("labels a position in cooldown", () => {

--- a/packages/ui/src/lib/escrowStatus.ts
+++ b/packages/ui/src/lib/escrowStatus.ts
@@ -18,6 +18,7 @@ export function isWithdrawable(position: ReleaseState, nowSeconds: bigint): bool
 
 export function positionStatusLabel(position: ReleaseState, nowSeconds: bigint): string {
   if (position.claimed) return "Claimed";
+  if (!position.released && !isRefundableDeposit(position)) return "Not refundable";
   if (!position.released) return "Held";
   return isWithdrawable(position, nowSeconds) ? "Withdrawable" : "Cooldown";
 }
@@ -33,19 +34,17 @@ export function isRefundableDeposit(position: { amount: bigint }): boolean {
   return position.amount > 0n;
 }
 
-// A read position belongs to `recipient` when the escrow still names them as the
-// refund recipient and the deposit is refundable. A null read (missing or failed)
-// never qualifies. Shared by the UI store and mirrors the CLI's filter so both
-// surface the same set of positions.
-export function isAccountPosition<T extends { recipient: string; amount: bigint }>(
+// A read position belongs to `recipient` when the escrow names them as the refund
+// recipient, regardless of the staked amount. A null read (missing or failed) never
+// qualifies. Zero-amount positions are kept so the UI can surface non-refundable
+// names (paid for by another account, or registered under a free personhood tier)
+// with a warning rather than hiding them; refundability is a display concern decided
+// by isRefundableDeposit, not a discovery filter.
+export function isAccountPosition<T extends { recipient: string }>(
   position: T | null,
   recipient: string,
 ): position is T {
-  return (
-    position !== null &&
-    isSameEvmAddress(position.recipient, recipient) &&
-    isRefundableDeposit(position)
-  );
+  return position !== null && isSameEvmAddress(position.recipient, recipient);
 }
 
 // Total still locked across positions. Withdrawn positions carry amount 0 (the

--- a/packages/ui/src/store/useEscrowStore.ts
+++ b/packages/ui/src/store/useEscrowStore.ts
@@ -82,7 +82,8 @@ export const useEscrowStore = defineStore("useEscrowStore", () => {
   // Labels are mirror-on-transfer and never deleted, so a released name (now held
   // by the escrow contract) still resolves through the caller's own label set;
   // the recipient filter drops names transferred away whose position rebound to
-  // someone else.
+  // someone else. Zero-amount positions are retained (not filtered) so the UI can
+  // mark non-refundable names; the refundable-amount check is a display concern.
   //
   // Reads run sequentially, mirroring the CLI. A parallel burst overruns the
   // chainHead_follow subscription, and every read that then sees "No active


### PR DESCRIPTION
## Description
This PR adds a warning label on names whose deposit was sent to the insurance funds, resulting in them having a 0 position in the escrow
## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [x] Chore

## Package

- [ ] `@parity/dotns-cli`
- [ ] Root/monorepo
- [ ] Documentation

## Related Issues

## Fixes 

## Checklist

### Code

- [x] Follows project style
- [x] `bun run lint` passes
- [x] `bun run format` passes
- [x] `bun run typecheck` passes

### Documentation

- [ ] README updated if needed
- [ ] Types updated if needed

### Breaking Changes

- [ ] No breaking changes
- [ ] Breaking changes documented below

**Breaking changes:**

## Testing

How to test:

1. 
2. 

## Notes