### PR TITLE
fix(register): stop applying PopRules label rules to governance registration

### DIFF
--- a/packages/cli/src/cli/commands/register.ts
+++ b/packages/cli/src/cli/commands/register.ts
@@ -4,8 +4,10 @@ import { checksumAddress, isAddress, type Address, type Hex } from "viem";
 import { formatErrorMessage, formatWeiAsEther } from "../../utils/formatting";
 import {
   classifyDomainName,
+  tryClassifyDomainName,
   ensureDomainNotRegistered,
   generateCommitment,
+  getWhitelistStatus,
   submitCommitment,
   waitForMinimumCommitmentAge,
   getPriceAndValidateEligibility,
@@ -501,11 +503,36 @@ async function executeGovernanceRegistration(
 
   validateGovernanceLabel(label);
 
+  // registerReserved is gated on the whitelist (or the controller owner), not on the
+  // caller's PoP tier. Surfaced as information only: the controller owner is also
+  // authorised, so a `false` here is a warning rather than a hard stop.
+  const whitelisted = await step("Checking governance whitelist", async () =>
+    getWhitelistStatus(session.ctx, session.caller).catch(() => null),
+  );
+  if (whitelisted === false) {
+    console.log(
+      chalk.yellow("  ⚠ caller is not whitelisted; ") +
+        chalk.gray(
+          "registerReserved reverts with NotWhiteListedOrOwner unless you own the controller",
+        ),
+    );
+  } else if (whitelisted === true) {
+    console.log(chalk.gray("  whitelisted: ") + chalk.green("yes"));
+  }
+
+  // A null classification means PopRules refuses to classify the label's *shape*
+  // (classifyName reverts). registerReserved does not consult PopRules, so that is
+  // not a blocker here — only a definite non-Reserved classification is.
   const classification = await step("Classifying name", async () =>
-    classifyDomainName(session.ctx, label),
+    tryClassifyDomainName(session.ctx, label),
   );
 
-  if (classification.requiredStatus !== ProofOfPersonhoodStatus.Reserved) {
+  if (classification === null) {
+    console.log(
+      chalk.yellow("  ⚠ PopRules cannot classify this label shape; ") +
+        chalk.gray("registerReserved bypasses PopRules, continuing"),
+    );
+  } else if (classification.requiredStatus !== ProofOfPersonhoodStatus.Reserved) {
     throw new Error(
       `Governance name must classify as Reserved; got ${ProofOfPersonhoodStatus[classification.requiredStatus]}`,
     );
@@ -514,7 +541,11 @@ async function executeGovernanceRegistration(
   await step("Checking availability", async () => ensureDomainNotRegistered(session.ctx, label));
 
   const { commitment, registration, secret } = await step("Generating commitment", async () =>
-    generateCommitment(session.ctx, label, { owner: session.caller, includeReverse: true }),
+    generateCommitment(session.ctx, label, {
+      owner: session.caller,
+      includeReverse: true,
+      governance: true,
+    }),
   );
   console.log(chalk.gray("  commitment: ") + chalk.blue(commitment));
   console.log(chalk.gray("  secret:     ") + chalk.yellow(redactSecret(secret)));

--- a/packages/cli/src/cli/commands/register.ts
+++ b/packages/cli/src/cli/commands/register.ts
@@ -501,6 +501,17 @@ async function executeGovernanceRegistration(
 ): Promise<void> {
   console.log(chalk.bold("\n🏛 Governance registration (commit-reveal)\n"));
 
+  // This path submits through DotnsRegistrarController.registerReserved, which
+  // never consults PopRules: its only on-chain label checks are isSingleLabel()
+  // (InvalidLabel) and length >= 3 (LabelTooShort). Hence validateGovernanceLabel
+  // rather than validateDomainLabel — the latter's "zero or exactly two trailing
+  // digits" rule mirrors PopRules and would reject labels the contract accepts,
+  // e.g. "dim2" (stem "dim" plus one trailing digit).
+  //
+  // The stem <= 5 bound it does apply is likewise not a registerReserved
+  // requirement; it mirrors PopRules' `stemLen <= 5 -> Reserved` classification.
+  // Kept deliberately: it holds this command to the reserved class it is for,
+  // rather than silently widening what a whitelisted account can mint here.
   validateGovernanceLabel(label);
 
   // registerReserved is gated on the whitelist (or the controller owner), not on the
@@ -522,9 +533,16 @@ async function executeGovernanceRegistration(
 
   // A null classification means PopRules refuses to classify the label's *shape*
   // (classifyName reverts). registerReserved does not consult PopRules, so that is
-  // not a blocker here — only a definite non-Reserved classification is.
+  // not a blocker here — only a definite non-Reserved classification is. Anything
+  // other than a revert propagates out of tryClassifyDomainName, so an unreachable
+  // chain cannot masquerade as "unclassifiable" and unlock this path.
+  let unclassifiableReason: string | undefined;
   const classification = await step("Classifying name", async () =>
-    tryClassifyDomainName(session.ctx, label),
+    tryClassifyDomainName(session.ctx, label, {
+      onUnclassifiable: (reason) => {
+        unclassifiableReason = reason;
+      },
+    }),
   );
 
   if (classification === null) {
@@ -532,6 +550,9 @@ async function executeGovernanceRegistration(
       chalk.yellow("  ⚠ PopRules cannot classify this label shape; ") +
         chalk.gray("registerReserved bypasses PopRules, continuing"),
     );
+    if (unclassifiableReason) {
+      console.log(chalk.gray(`    ${unclassifiableReason}`));
+    }
   } else if (classification.requiredStatus !== ProofOfPersonhoodStatus.Reserved) {
     throw new Error(
       `Governance name must classify as Reserved; got ${ProofOfPersonhoodStatus[classification.requiredStatus]}`,

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -38,7 +38,12 @@ import {
   COMMITMENT_POLL_TIMEOUT_MS,
   COMMITMENT_POLL_INTERVAL_MS,
 } from "../utils/constants";
-import { validateDomainLabel, normaliseLabel, stripTrailingDigits } from "../utils/validation";
+import {
+  validateDomainLabel,
+  validateGovernanceLabel,
+  normaliseLabel,
+  stripTrailingDigits,
+} from "../utils/validation";
 import { computeDomainTokenId } from "../utils/contractInteractions";
 import { convertWeiToNative } from "../utils/formatting";
 import { isSameEvmAddress } from "../utils/address";
@@ -118,6 +123,22 @@ export async function classifyDomainName(
   };
 }
 
+// classifyName is `pure` but reverts with PopError for label shapes PopRules
+// refuses to classify at all (one, or three or more, trailing digits). Callers that
+// treat the classification as advisory — notably the governance path, which submits
+// through registerReserved and so bypasses PopRules entirely — get null rather than
+// a thrown error and can decide for themselves whether to continue.
+export async function tryClassifyDomainName(
+  ctx: DotnsContext,
+  name: string,
+): Promise<NameClassification | null> {
+  try {
+    return await classifyDomainName(ctx, name);
+  } catch {
+    return null;
+  }
+}
+
 export async function ensureDomainNotRegistered(ctx: DotnsContext, name: string): Promise<void> {
   const label = normaliseLabel(name);
   const owner = await readDomainOwner(ctx, label);
@@ -128,6 +149,12 @@ export type GenerateCommitmentOptions = {
   owner?: Address;
   secret?: Hex;
   includeReverse?: boolean;
+  /**
+   * Set for commitments that will be revealed through registerReserved. That path
+   * bypasses PopRules, so the label is validated against the controller's own rules
+   * (validateGovernanceLabel) instead of the PopRules-derived validateDomainLabel.
+   */
+  governance?: boolean;
 };
 
 export type GeneratedCommitment = {
@@ -155,7 +182,11 @@ export async function generateCommitment(
   opts: GenerateCommitmentOptions = {},
 ): Promise<GeneratedCommitment> {
   const label = normaliseLabel(name);
-  validateDomainLabel(label);
+  if (opts.governance) {
+    validateGovernanceLabel(label);
+  } else {
+    validateDomainLabel(label);
+  }
 
   const owner = opts.owner ?? (await ownEvmAddress(ctx));
   const secret = resolveSecret(opts.secret);

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -44,7 +44,7 @@ import {
   normaliseLabel,
   stripTrailingDigits,
 } from "../utils/validation";
-import { computeDomainTokenId } from "../utils/contractInteractions";
+import { computeDomainTokenId, ContractRevertError } from "../utils/contractInteractions";
 import { convertWeiToNative } from "../utils/formatting";
 import { isSameEvmAddress } from "../utils/address";
 
@@ -123,18 +123,34 @@ export async function classifyDomainName(
   };
 }
 
-// classifyName is `pure` but reverts with PopError for label shapes PopRules
-// refuses to classify at all (one, or three or more, trailing digits). Callers that
-// treat the classification as advisory — notably the governance path, which submits
-// through registerReserved and so bypasses PopRules entirely — get null rather than
-// a thrown error and can decide for themselves whether to continue.
+/**
+ * {@link classifyDomainName}, but returns `null` when PopRules *refuses to
+ * classify* the label at all rather than throwing.
+ *
+ * `classifyName` is `pure`, yet it reverts with `PopError` for label shapes
+ * PopRules rejects outright (one, or three or more, trailing digits). For callers
+ * that treat the classification as advisory — notably the governance path, which
+ * submits through `registerReserved` and bypasses PopRules entirely — that revert
+ * is an answer, not a failure.
+ *
+ * Only a revert is converted to `null`. An unreachable chain, an unmapped origin
+ * or an ABI mismatch all propagate: reinterpreting those as "unclassifiable"
+ * would let a transient RPC failure silently unlock the governance path, which is
+ * precisely the wrong behaviour under uncertainty.
+ *
+ * The revert reason is handed to `onUnclassifiable` rather than printed, so the
+ * reason is never lost while this layer stays free of presentation concerns.
+ */
 export async function tryClassifyDomainName(
   ctx: DotnsContext,
   name: string,
+  opts: { onUnclassifiable?: (reason: string) => void } = {},
 ): Promise<NameClassification | null> {
   try {
     return await classifyDomainName(ctx, name);
-  } catch {
+  } catch (error) {
+    if (!(error instanceof ContractRevertError)) throw error;
+    opts.onUnclassifiable?.(error.message);
     return null;
   }
 }

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -12,6 +12,7 @@ export type { DotnsContext, OperationStatus, CreateDotnsContextOptions } from ".
 
 export {
   classifyDomainName,
+  tryClassifyDomainName,
   ensureDomainNotRegistered,
   generateCommitment,
   submitCommitment,

--- a/packages/cli/src/simpleExamples/03_register_governance.ts
+++ b/packages/cli/src/simpleExamples/03_register_governance.ts
@@ -22,10 +22,7 @@ async function main() {
   // null means PopRules refuses to classify this label shape at all. registerReserved
   // bypasses PopRules, so that is not a blocker — only a definite non-Reserved is.
   const classification = await tryClassifyDomainName(ctx, label);
-  if (
-    classification !== null &&
-    classification.requiredStatus !== ProofOfPersonhoodStatus.Reserved
-  ) {
+  if (classification && classification.requiredStatus !== ProofOfPersonhoodStatus.Reserved) {
     throw new Error(
       `Governance name must classify as Reserved; got ${ProofOfPersonhoodStatus[classification.requiredStatus]}`,
     );

--- a/packages/cli/src/simpleExamples/03_register_governance.ts
+++ b/packages/cli/src/simpleExamples/03_register_governance.ts
@@ -3,7 +3,7 @@ import { validateGovernanceLabel } from "../utils/validation";
 import { ProofOfPersonhoodStatus } from "../types/types";
 
 import {
-  classifyDomainName,
+  tryClassifyDomainName,
   ensureDomainNotRegistered,
   generateCommitment,
   submitCommitment,
@@ -19,8 +19,13 @@ async function main() {
 
   validateGovernanceLabel(label);
 
-  const classification = await classifyDomainName(ctx, label);
-  if (classification.requiredStatus !== ProofOfPersonhoodStatus.Reserved) {
+  // null means PopRules refuses to classify this label shape at all. registerReserved
+  // bypasses PopRules, so that is not a blocker — only a definite non-Reserved is.
+  const classification = await tryClassifyDomainName(ctx, label);
+  if (
+    classification !== null &&
+    classification.requiredStatus !== ProofOfPersonhoodStatus.Reserved
+  ) {
     throw new Error(
       `Governance name must classify as Reserved; got ${ProofOfPersonhoodStatus[classification.requiredStatus]}`,
     );
@@ -30,6 +35,7 @@ async function main() {
 
   const { commitment, registration } = await generateCommitment(ctx, label, {
     includeReverse: true,
+    governance: true,
   });
 
   await submitCommitment(ctx, commitment);

--- a/packages/cli/src/utils/contractInteractions.ts
+++ b/packages/cli/src/utils/contractInteractions.ts
@@ -24,6 +24,22 @@ export function isRevertFlag(flags: bigint): boolean {
   return (flags & 1n) === 1n;
 }
 
+/**
+ * A revert carrying revert data: the contract ran and rejected the call, so the
+ * failure is an answer rather than a failure to reach the chain.
+ *
+ * Deliberately not raised for the empty-data revert, which means an unmapped
+ * origin ({@link UNMAPPED_ORIGIN_REVERT_HINT}) — a setup problem with its own
+ * remedy — nor for RPC failures, ABI mismatches or decode errors. Callers that
+ * treat a revert as information must not treat those the same way.
+ */
+export class ContractRevertError extends Error {
+  constructor(revertReason: string) {
+    super(`Contract reverted: ${revertReason}`);
+    this.name = "ContractRevertError";
+  }
+}
+
 export function buildRevertError(data: Hex, abi: Abi): Error {
   if (data === "0x") {
     return new Error(UNMAPPED_ORIGIN_REVERT_HINT);
@@ -38,7 +54,7 @@ export function buildRevertError(data: Hex, abi: Abi): Error {
   } catch {
     // Unknown error selector — fall back to raw hex
   }
-  return new Error(`Contract reverted: ${revertReason}`);
+  return new ContractRevertError(revertReason);
 }
 
 export function decodeContractRevertError(data: Hex, abi: Abi, context: string): Error {

--- a/packages/cli/src/utils/validation.ts
+++ b/packages/cli/src/utils/validation.ts
@@ -72,18 +72,16 @@ export function validateDomainLabel(label: string): void {
   }
 }
 
-// Governance registration goes through DotnsRegistrarController.registerReserved,
-// which never consults PopRules: its only on-chain label checks are isSingleLabel()
-// (InvalidLabel) and length >= 3 (LabelTooShort). Deliberately NOT applying
-// validateDomainLabel's trailing-digit rule here — that rule mirrors PopRules,
-// which this path bypasses, so enforcing it would reject labels the contract
-// accepts (for example "dim2", base "dim" plus one trailing digit).
-//
-// The stem-length bound below is likewise not a registerReserved requirement (it
-// mirrors PopRules' `stemLen <= 5 -> Reserved` classification), but it is kept on
-// purpose: it preserves this command's intent that governance registration is for
-// short reserved names, and avoids silently widening what a whitelisted account
-// can mint through the CLI.
+/**
+ * Validates a label for the governance registration path.
+ *
+ * Intentionally does **not** delegate to {@link validateDomainLabel}: that
+ * function's trailing-digit rule mirrors PopRules, and this path does not go
+ * through PopRules. Checks the canonical label shape, a minimum length of 3, and
+ * bounds the stem to the reserved class this path exists for.
+ *
+ * `executeGovernanceRegistration` documents why each bound is or is not applied.
+ */
 export function validateGovernanceLabel(label: string): void {
   validateCanonicalLabel(label, "governance label");
 

--- a/packages/cli/src/utils/validation.ts
+++ b/packages/cli/src/utils/validation.ts
@@ -72,8 +72,24 @@ export function validateDomainLabel(label: string): void {
   }
 }
 
+// Governance registration goes through DotnsRegistrarController.registerReserved,
+// which never consults PopRules: its only on-chain label checks are isSingleLabel()
+// (InvalidLabel) and length >= 3 (LabelTooShort). Deliberately NOT applying
+// validateDomainLabel's trailing-digit rule here — that rule mirrors PopRules,
+// which this path bypasses, so enforcing it would reject labels the contract
+// accepts (for example "dim2", base "dim" plus one trailing digit).
+//
+// The stem-length bound below is likewise not a registerReserved requirement (it
+// mirrors PopRules' `stemLen <= 5 -> Reserved` classification), but it is kept on
+// purpose: it preserves this command's intent that governance registration is for
+// short reserved names, and avoids silently widening what a whitelisted account
+// can mint through the CLI.
 export function validateGovernanceLabel(label: string): void {
-  validateDomainLabel(label);
+  validateCanonicalLabel(label, "governance label");
+
+  if (label.length < 3) {
+    throw new Error("Invalid governance label: minimum length of 3 characters");
+  }
 
   const baseName = stripTrailingDigits(label);
   if (baseName.length > 5) {

--- a/packages/cli/tests/unit/utils/validation.test.ts
+++ b/packages/cli/tests/unit/utils/validation.test.ts
@@ -145,9 +145,50 @@ describe("validateGovernanceLabel stem-length rule", () => {
     );
   });
 
-  test("inherits the digit-suffix rule from validateDomainLabel", () => {
-    expect(() => validateGovernanceLabel("abcd1")).toThrow(
-      /must have either no trailing digits or exactly two/,
+  test("measures the stem with trailing digits stripped", () => {
+    expect(() => validateGovernanceLabel("abcde1")).not.toThrow();
+    expect(() => validateGovernanceLabel("abcdef1")).toThrow(
+      /base name must be 5 characters or fewer/,
     );
+  });
+
+  test("does not apply the PopRules digit-suffix rule", () => {
+    expect(() => validateGovernanceLabel("abcd1")).not.toThrow();
+  });
+});
+
+describe("validateGovernanceLabel digit-suffix independence", () => {
+  test("accepts a single trailing digit", () => {
+    // The real case: registerReserved never consults PopRules, so "dim2"
+    // (base "dim" plus one trailing digit) must be registrable.
+    expect(() => validateGovernanceLabel("dim2")).not.toThrow();
+  });
+
+  test("accepts three or more trailing digits", () => {
+    expect(() => validateGovernanceLabel("dim123")).not.toThrow();
+    expect(() => validateGovernanceLabel("dim9999")).not.toThrow();
+  });
+
+  test("accepts labels with no trailing digits", () => {
+    expect(() => validateGovernanceLabel("game")).not.toThrow();
+  });
+});
+
+describe("validateGovernanceLabel canonical-label rules", () => {
+  test("rejects uppercase characters", () => {
+    expect(() => validateGovernanceLabel("Dim2")).toThrow(/governance label/);
+  });
+
+  test("rejects labels containing a dot", () => {
+    expect(() => validateGovernanceLabel("dim.dot")).toThrow(/governance label/);
+  });
+
+  test("rejects leading or trailing hyphen", () => {
+    expect(() => validateGovernanceLabel("-dim")).toThrow(/governance label/);
+    expect(() => validateGovernanceLabel("dim-")).toThrow(/governance label/);
+  });
+
+  test("rejects labels shorter than three characters", () => {
+    expect(() => validateGovernanceLabel("ab")).toThrow(/minimum length of 3 characters/);
   });
 });

--- a/packages/cli/tests/unit/utils/validation.test.ts
+++ b/packages/cli/tests/unit/utils/validation.test.ts
@@ -157,20 +157,43 @@ describe("validateGovernanceLabel stem-length rule", () => {
   });
 });
 
-describe("validateGovernanceLabel digit-suffix independence", () => {
-  test("accepts a single trailing digit", () => {
-    // The real case: registerReserved never consults PopRules, so "dim2"
-    // (base "dim" plus one trailing digit) must be registrable.
+// The digit-suffix rule ("zero or exactly two trailing digits") is a PopRules
+// rule. registerReserved never consults PopRules — its only on-chain label checks
+// are isSingleLabel() and length >= 3 — so applying that rule to this path would
+// reject labels the contract accepts. Governance labels only.
+//
+// The contrast with the normal path is asserted at the bottom of this block, so
+// the two rule sets can be read side by side rather than two files apart.
+describe("validateGovernanceLabel is independent of the PopRules digit-suffix rule", () => {
+  test("accepts ONE trailing digit, which PopRules rejects outright", () => {
+    // registered on-chain: dim2.dot, paseo-next-v2
     expect(() => validateGovernanceLabel("dim2")).not.toThrow();
   });
 
-  test("accepts three or more trailing digits", () => {
+  test("accepts THREE OR MORE trailing digits, which PopRules also rejects", () => {
     expect(() => validateGovernanceLabel("dim123")).not.toThrow();
     expect(() => validateGovernanceLabel("dim9999")).not.toThrow();
   });
 
-  test("accepts labels with no trailing digits", () => {
+  test("accepts zero trailing digits", () => {
     expect(() => validateGovernanceLabel("game")).not.toThrow();
+  });
+
+  test("accepts exactly two trailing digits", () => {
+    expect(() => validateGovernanceLabel("dim22")).not.toThrow();
+  });
+
+  // Guards the scope of the relaxation: normal registration is untouched, so every
+  // non-governance name still obeys the 0-or-2 rule.
+  test("the NORMAL path still enforces 0-or-2 trailing digits", () => {
+    expect(() => validateDomainLabel("dim2")).toThrow(
+      /must have either no trailing digits or exactly two/,
+    );
+    expect(() => validateDomainLabel("dim123")).toThrow(
+      /must have either no trailing digits or exactly two/,
+    );
+    expect(() => validateDomainLabel("dimtwo")).not.toThrow();
+    expect(() => validateDomainLabel("dimtwo01")).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Description

`registerReserved` on `DotnsRegistrarController` never consults `IPopRules` — its only on-chain label checks are `isSingleLabel()` and `length >= 3`. But the CLI applied PopRules-derived label validation to that path anyway, so a whitelisted account could not register labels the contract accepts.

The concrete case: `dim2.dot` (base `dim` plus exactly **one** trailing digit). `validateGovernanceLabel` delegated to `validateDomainLabel`, which enforces PopRules' "zero or exactly two trailing digits" rule and fails with:

```
Invalid domain label: must have either no trailing digits or exactly two, found 1
```

That rule mirrors a contract this path bypasses. `game.dot` (base 4, zero trailing digits) already worked, which is why this went unnoticed.

## What changed

- **`validateGovernanceLabel`** no longer delegates to `validateDomainLabel`. It validates against the controller's own rules — `validateCanonicalLabel` (the existing `isSingleLabel()` mirror) plus `length >= 3`.
- **`generateCommitment`** takes a `governance` option. This is load-bearing: it validated independently, so without this the change above has no effect.
- **The `requiredStatus === Reserved` gate is now fault-tolerant, not merely widened.** `classifyName` *reverts* (`InvalidName`) for one or three-plus trailing digits, so for `dim2` there is no status value to compare against. New `tryClassifyDomainName` returns `null` on revert; the governance path treats `null` as advisory (warn and continue) while still rejecting a *definite* non-Reserved classification. Restructuring was unavoidable here — relaxing the comparison alone cannot work when the read itself throws.
- **Whitelist status is surfaced as information, not a gate** — `onlyWhiteListedOrOwner` also authorises the controller owner, so a `false` is a warning rather than a hard stop.
- `tryClassifyDomainName` is exported from `core`, and `simpleExamples/03_register_governance.ts` is fixed — it reproduced the same gate.

### One deliberate non-change

The `baseName.length > 5` stem bound is *also* PopRules-derived and not a `registerReserved` requirement — the contract would accept `vitalik.dot` via governance. I kept it: it preserves the command's intent that governance registration is for short reserved names, and dropping it silently widens what a whitelisted account can mint. Happy to remove it if you'd rather the CLI mirror the contract exactly; it's a one-line change and does not affect the `dim2` case (stem `dim` = 3).

## Related Issues

Client-side counterpart of the same gap in the deploy tooling: paritytech/bulletin-deploy#1185. The whitelist itself came from paritytech/dotns#195.

No existing issue in this repo covers this. For context on how it arose: #148 introduced the trailing-digit rule, framed purely as a PopRules mirror ("The CLI now catches this before submition instead of relying on the on-chain revert") — correct for `register()`, but the governance path was not considered. #158 notes governance registration tests were removed as depending on whitelist state, so this path has had no test coverage since.

## Testing

`bun test tests/unit/utils/validation.test.ts` → **31 pass, 0 fail**.

Inverted the assertion that locked in the old behaviour (`validateGovernanceLabel("abcd1")` was asserted to *throw*) and added coverage for: one trailing digit accepted, three-plus accepted, zero still accepted, canonical-label rejections (uppercase, embedded dot, leading/trailing hyphen), the `length < 3` floor, and the retained stem>5 bound. The `validateDomainLabel` digit tests are untouched — the regular path still needs that rule.

### Note on the full unit suite

`bun test tests/unit/` gives **103 pass / 23 fail** on this branch and **95 pass / 23 fail** on `main` — same 23 failures, so they are pre-existing and unrelated. All 23 are one root cause:

```
error: Cannot find module '@polkadot-api/descriptors' from '.../src/cli/commands/info.ts'
```

Incidental finding worth a separate look: `packages/cli/package.json` at `main` does **not** declare `@polkadot-api/descriptors`. `bunx papi generate` (the `prepare` script) adds the `file:.papi/descriptors` entry. So a fresh clone that runs `bun install` before `prepare` gets 23 failing unit tests, and `bun install` afterwards leaves a stub `node_modules/@polkadot-api/descriptors` containing only a `package.json`. CI works because of its step ordering. I did not commit the generated `package.json` change.

## Breaking Changes

Behavioural change to name interpretation on the governance path only — it now accepts a strict superset of labels. `CONTRIBUTING.md` asks that changes to name interpretation be treated as breaking for clients, so flagging it explicitly: nothing that previously succeeded now fails; labels that previously threw client-side may now proceed to `registerReserved`. The regular `register()` path is untouched.

## Checklist

- [x] `bunx prettier --check` on changed files — clean
- [x] `bunx eslint` on changed files — clean
- [x] Tests added for changed name-interpretation behaviour
- [x] No version bump (tag-driven releases; `packages/cli/package.json` is private)
- [x] `bunx tsc --noEmit` — 16 errors locally, all cascading from the pre-existing missing `@polkadot-api/descriptors` module described above (`TS2307`, plus downstream `TS7006` implicit-anys from the untyped import). **None are in any file this PR touches**: `utils/validation.ts`, `commands/register.ts`, `cli/commands/register.ts`, `core/index.ts`, `simpleExamples/03_register_governance.ts` and `tests/unit/utils/validation.test.ts` are all clean. CI should be green since its step ordering generates the descriptors first.
